### PR TITLE
Fixed script to work on my Debian. 

### DIFF
--- a/install/install_deps.sh
+++ b/install/install_deps.sh
@@ -1,6 +1,23 @@
 #!/bin/sh
 
 #Script to install developer dependancies for the Blender Nif Plugin
-
-python3 -m pip install Sphinx --target="%APPDATABLENDERADDONS%/modules"
-python3 -m pip install nose --target="%APPDATABLENDERADDONS%/modules"
+for BLENDERVERSION in 2.66 2.65 2.64 2.63 2.62
+do
+  BLENDERADDONS=~/.blender/$BLENDERVERSION/scripts/addons
+  if [ -e ~/.blender/$BLENDERVERSION/ ]
+  then
+    python3 -m pip install Sphinx --target="$BLENDERADDONS/modules" && python3 -m pip install nose --target="$BLENDERADDONS/modules" && installsuccess=1
+    break
+  fi
+done
+if [ $installsuccess ]
+then
+  echo "Dependencies were successfully installed in: $BLENDERADDONS/modules"
+else
+  if [ -e ~/.blender/$BLENDERVERSION/ ]
+  then
+    echo "Install failed. (Sorry no clear reason here. Check the output above.)"
+  else
+    echo "Install failed: No compatible blender version found."
+  fi
+fi


### PR DESCRIPTION
Original would install to path from Windows Environment Variable.
Made installs conditional, a failure at the start will abort the entire install.
Added some better reporting.
User will now get a message if the install was “successful” (did not abort)
User will get a message that says to check the installer output if it failed during install.
User will get a message if no data location could be found for the supported Blender versions.