### PR TITLE
Git clone requires use of --recursive to checkout submodule pyffi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,5 +28,5 @@ Support
 Fork
 ----
 
-* git clone git://github.com/niftools/blender_nif_plugin.git
+* git clone --recursive git://github.com/niftools/blender_nif_plugin.git
 * http://github.com/niftools/blender_nif_plugin


### PR DESCRIPTION
The install script would not run for me even after I fixed some errors in it (I'll open a separate pull request when I can test those fixes.)
I realised then that when I forked the repository I used a normal clone. However that does not download the pyffi, leaving that folder empty, whereas the install script assumes it will be cloned.

If the repo is forked with '--recursive' the pyffi submodule should be checked out recursively. (Could not verify, link seems dead, see  #208)

It seemed a good idea to show that in the manual.