### PR TITLE
Fixed multiple issues to make it work.

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-VERSION=`cat ${DIR}/../io_scene_nif/VERSION`
+DIR=`pwd`/`dirname $0`
+VERSION=`cat $DIR/../io_scene_nif/VERSION`
 NAME="blender_nif_plugin"
 
 for BLENDERVERSION in 2.66 2.65 2.64 2.63 2.62
@@ -30,5 +30,4 @@ rm -rf $BLENDERADDONS/io_scene_nif/
 sh $DIR/makezip.sh
 
 # copy files from repository to blender addons folder
-unzip "$DIR/${NAME}-${VERSION}.zip" -d $BLENDERADDONS
-
+unzip -q "$DIR/$NAME-$VERSION.zip" -d $BLENDERADDONS

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 DIR=`pwd`/`dirname $0`
-VERSION=`cat $DIR/../io_scene_nif/VERSION`
+VERSION=`cat ${DIR}/../io_scene_nif/VERSION`
 NAME="blender_nif_plugin"
 
 for BLENDERVERSION in 2.66 2.65 2.64 2.63 2.62
@@ -27,7 +27,7 @@ mkdir -p $BLENDERADDONS
 rm -rf $BLENDERADDONS/io_scene_nif/
 
 # create zip
-sh $DIR/makezip.sh
+sh ${DIR}/makezip.sh
 
 # copy files from repository to blender addons folder
 unzip -q "$DIR/$NAME-$VERSION.zip" -d $BLENDERADDONS

--- a/install/makezip.sh
+++ b/install/makezip.sh
@@ -1,33 +1,32 @@
-#!/bin/sh
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#!/bin/bash
+DIR=`dirname $0`
 VERSION=`cat ${DIR}/../io_scene_nif/VERSION`
 NAME="blender_nif_plugin"
 ROOT=${DIR}/..
 
-pushd $ROOT
-git clean -xfd
-git submodule foreach --recursive git clean -xfd
-popd
+cd $ROOT
+git clean -xfdq
+git submodule foreach --recursive git clean -xfdq
+cd $DIR
 
 mkdir ${DIR}/temp
 
-pushd ${DIR}/temp
+cd ${DIR}/temp
 cp -r ${ROOT}/io_scene_nif/ .
 mkdir io_scene_nif/modules
 cp -r ${ROOT}/pyffi/pyffi/ io_scene_nif/modules
 cp ${ROOT}/pyffi/*.rst io_scene_nif/modules/pyffi
-rm -r io_scene_nif/modules/pyffi/formats/cgf
-rm -r io_scene_nif/modules/pyffi/formats/dae
-rm -r io_scene_nif/modules/pyffi/formats/psk
-rm -r io_scene_nif/modules/pyffi/formats/rockstar
-rm -r io_scene_nif/modules/pyffi/formats/tga
-rm -r io_scene_nif/modules/pyffi/qskope
+rm -rf io_scene_nif/modules/pyffi/formats/cgf
+rm -rf io_scene_nif/modules/pyffi/formats/dae
+rm -rf io_scene_nif/modules/pyffi/formats/psk
+rm -rf io_scene_nif/modules/pyffi/formats/rockstar
+rm -rf io_scene_nif/modules/pyffi/formats/tga
+rm -rf io_scene_nif/modules/pyffi/qskope
 cp ${ROOT}/AUTHORS.rst io_scene_nif
 cp ${ROOT}/CHANGELOG.rst io_scene_nif
 cp ${ROOT}/LICENSE.rst io_scene_nif
 cp ${ROOT}/README.rst io_scene_nif
-zip -9r "${DIR}/${NAME}-${VERSION}.zip" io_scene_nif -x \*/__pycache__/\* -x \*/.git\* -x \*/.project -x \*/fileformat.dtd
-popd
+zip -9rq "${DIR}/${NAME}-${VERSION}.zip" io_scene_nif -x \*/__pycache__/\* -x \*/.git\* -x \*/.project -x \*/fileformat.dtd
+cd $DIR
 
 rm -r ${DIR}/temp


### PR DESCRIPTION
- makezip.sh relied on rather complex and specifix bash functionality.
- makezip.sh was called from install.sh using "sh", so on systems
  where sh is not bash, install failed.
- Replaced bash specific things with more generic shell commands.
- Several rm commands were trying to delete files that might not be there
  this would show apparent errors in the install output, even though
  nothing was wrong.
- Made the process of removing, creating and extracting the zip entirely
  quiet to the user (errors will be shown). The only reason for the construction
  seems to be that windows lacks a tool that allows one to copy but exclude
  files matching a certain pattern.