### PR TITLE
Fix : Edit bones recursive null reference.

### DIFF
--- a/io_scene_nif/armaturesys/armature_import.py
+++ b/io_scene_nif/armaturesys/armature_import.py
@@ -257,7 +257,6 @@ class Armature():
 			b_child_bone.parent = b_bone
 			bpy.ops.object.mode_set(mode='OBJECT',toggle=False)
 			b_bone = b_armatureData.bones[bone_name]
-			b_child_bone = b_armatureData.bones[b_child_bone.name]
 
 
 		


### PR DESCRIPTION
Remove access to invalid EditBone in b_child_bone after switching to OBJECT mode.
Variable is also not used.