### PR TITLE
Fixed makezip.sh to run to completion when called with relative path

### DIFF
--- a/install/makezip.sh
+++ b/install/makezip.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-DIR=`dirname $0`
+DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 VERSION=`cat ${DIR}/../io_scene_nif/VERSION`
 NAME="blender_nif_plugin"
 ROOT=${DIR}/..


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
This change makes it possible to create an installer on a shell enviromnent

## Fixes Known Issues
N/A

## Documentation
Code change is to perform according to existing documention.

## Testing
This change makes it possible to, for example:
$  cd install
$ ./makezip.sh

### Manual
Ran the above commands

### Automated


## Additional Information
BTW this is my first attempt at contributing to a project using git or GitHub; so I hope I am doing it right.