### PR TITLE
Small fixes for errors in recent refactoring

### DIFF
--- a/io_scene_nif/armaturesys/armature_export.py
+++ b/io_scene_nif/armaturesys/armature_export.py
@@ -162,7 +162,8 @@ class Armature():
                         node.flags = 0x0196
                 else:
                     node.flags = 0x0002 # default for Morrowind bones
-            self.nif_export.set_object_matrix(bone, 'localspace', node) # rest pose
+
+            self.nif_export.objecthelper.set_object_matrix(bone, 'localspace', node) # rest pose
 
             # bone rotations are stored in the IPO relative to the rest position
             # so we must take the rest position into account

--- a/io_scene_nif/io/nif.py
+++ b/io_scene_nif/io/nif.py
@@ -46,7 +46,7 @@ class NifFile():
     """Class to load and save a NifFile"""
     
     @staticmethod
-    def load_nif(cls, file_path):
+    def load_nif(file_path):
         """Loads a nif from the given file path"""
         NifLog.info("Importing {0}".format(file_path))
 


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Bug fixes introduced by refactoring for file loading and object matrix code.

## Fixes Known Issues
Fix issue with loading nif
```
Traceback (most recent call last):
  File "AppData\Roaming\Blender Foundation\Blender\2.74\scripts\addons\io_scene_nif\operators\nif_import_op.py", line 174, in execute
    return nif_import.NifImport(self, context).execute()
  File "\AppData\Roaming\Blender Foundation\Blender\2.74\scripts\addons\io_scene_nif\nif_import.py", line 119, in execute
    self.data = NifFile.load_nif(NifOp.props.filepath)
TypeError: load_nif() missing 1 required positional argument: 'file_path'
```

Fixes issue reported by thewiimote
``` 
Traceback (most recent call last):
  File "Blender\2.74\scripts\addons\io_scene_nif\operators\nif_export_op.py", line 171, in execute
    return nif_export.NifExport(self, context).execute()
  File "Blender\2.74\scripts\addons\io_scene_nif\nif_export.py", line 236, in execute
    root_block = self.objecthelper.export_node(None, 'none', None, '')
  File "Blender\2.74\scripts\addons\io_scene_nif\objectsys\object_export.py", line 288, in export_node
    self.nif_export.armaturehelper.export_bones(b_obj, node)
  File "Blender\2.74\scripts\addons\io_scene_nif\armaturesys\armature_export.py", line 165, in export_bones
    self.nif_export.set_object_matrix(bone, 'localspace', node) # rest pose
AttributeError: 'NifExport' object has no attribute 'set_object_matrix'
```

## Documentation
N/A

## Testing
Imported & Exported skyrim mug, which reproduced both issues

### Manual
Verified import was working up to previous support level

### Automated
- Smoke
- Integration

## Additional Information
NA