### PR TITLE
Fixes for errors in refactoring

### DIFF
--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -229,6 +229,11 @@ class NifExport(NifCommon):
             # -----------
             NifLog.info("Exporting")
 
+            # find nif version to write
+            #TODO Move fully to scene level
+            self.version = NifOp.op.version[NifOp.props.game]
+            self.user_version, self.user_version_2 = scene_export.get_version_info(NifOp.props)
+
             # create a nif object
 
             # export the root node (the name is fixed later to avoid confusing the
@@ -612,11 +617,6 @@ class NifExport(NifCommon):
             # export nif file:
             # ----------------
 
-            # find nif version to write
-            #TODO Move fully to scene level
-            self.version = NifOp.op.version[NifOp.props.game]
-            self.user_version, self.user_version_2 = scene_export.get_version_info(NifOp.props)
-            
             NifLog.info("Writing NIF version 0x%08X" % self.version)
 
             if export_animation != 'ANIM_KF':

--- a/io_scene_nif/objectsys/object_export.py
+++ b/io_scene_nif/objectsys/object_export.py
@@ -1176,7 +1176,7 @@ class MeshHelper():
                         # fix geometry rest pose: transform relative to
                         # skeleton root
                         skindata.set_transform(
-                            self.nif_export.get_object_matrix(b_obj, 'localspace').get_inverse())
+                            self.nif_export.objecthelper.get_object_matrix(b_obj, 'localspace').get_inverse())
                        
                         # Vertex weights,  find weights and normalization factors
                         vert_list = {}


### PR DESCRIPTION
 @niftools/blender-nif-plugin-reviewer 
# Overview

Fixes 2 issues
- Refactored code fails on armature export
- Value for version not assigned, fails export
## Fixes Known Issues

Adapt new location of get_object_matrix in objecthelper - Reported by thewiimote
## Documentation

N/A
## Testing

[Overview of testing required to ensure functionality is correctly implemented]
### Manual

[Order steps to manually verify updates are working correctly]
### Automated

[List of tests run, updated or added to avoid future regressions]
## Additional Information

```
Traceback (most recent call last):
  File "\addons\io_scene_nif\operators\nif_export_op.py", line 171, in execute
    return nif_export.NifExport(self, context).execute()
  File "\addons\io_scene_nif\nif_export.py", line 242, in execute
    root_block = self.objecthelper.export_node(None, 'none', None, '')
  File "\addons\io_scene_nif\objectsys\object_export.py", line 292, in export_node
    self.nif_export.armaturehelper.export_children(b_obj, node)
  File "\addons\io_scene_nif\armaturesys\armature_export.py", line 226, in export_children
    parent_block, b_obj_child.name)
  File "\addons\io_scene_nif\objectsys\object_export.py", line 212, in export_node
    self.mesh_helper.export_tri_shapes(b_obj, space, parent_block, node_name)
  File "\addons\io_scene_nif\objectsys\object_export.py", line 1289, in export_tri_shapes
    if (self.nif_export.version >= 0x04020100
AttributeError: 'NifExport' object has no attribute 'version'
```
