### PR TITLE
allow exporting of object while ignoring non-uv textures

### DIFF
--- a/io_scene_nif/objectsys/object_export.py
+++ b/io_scene_nif/objectsys/object_export.py
@@ -916,9 +916,8 @@ class MeshHelper():
                     # if we have uv coordinates
                     # double check that we have uv data
                     if not b_mesh.uv_layer_stencil:
-                        raise nif_utils.NifError(
-                            "ERROR%t|Create a UV map for every texture,"
-                            " and run the script again.")
+                        NifLog.warn("No UV map for texture associated with poly {0} of selected "
+                                    "mesh '{1}'.".format(str(poly.index), b_mesh.name))
                 # find (vert, uv-vert, normal, vcol) quad, and if not found, create it
                 f_index = [ -1 ] * f_numverts
                 for i, loop_index in enumerate(
@@ -945,10 +944,8 @@ class MeshHelper():
                             #b_mesh.uv_layers[0].data[poly.index].uv
                             fuv.append(b_mesh.uv_layers[uvlayer].data[loop_index].uv)
                         else:
-                            raise nif_utils.NifError(
-                                "ERROR%t|Texture is set to use UV"
-                                " but no UV Map is Selected for"
-                                " Mapping > Map")
+                            NifLog.warn("Texture is set to use UV but no UV Map is Selected "
+                                        "for Mapping > Map")
                     fcol = None
 
                     '''TODO: Need to map b_verts -> n_verts'''
@@ -1117,6 +1114,7 @@ class MeshHelper():
                 tridata.uv_sets.update_size()
                 for j, uvlayer in enumerate(mesh_uvlayers):
                     for i, uv in enumerate(tridata.uv_sets[j]):
+                        if len(uvlist[i]) == 0: continue  # skip non-uv textures
                         uv.u = uvlist[i][j][0]
                         uv.v = 1.0 - uvlist[i][j][1] # opengl standard
 

--- a/io_scene_nif/texturesys/texture_export.py
+++ b/io_scene_nif/texturesys/texture_export.py
@@ -646,6 +646,7 @@ class TextureHelper():
     
             # nif only support UV-mapped textures
             else:
-                raise nif_utils.NifError("Non-UV texture in mesh '{0}', material '{1}'."
-                             "Either delete all non-UV textures or in the Shading Panel under Material Buttons".format(b_obj.name, b_mat.name))
-
+                NifLog.warn("Non-UV texture in mesh '{0}', material '{1}'. Either delete all "
+                            "non-UV textures or create a UV map for every texture associated "
+                            "with selected object and run the script again.".
+                            format(b_obj.name, b_mat.name))


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
allow exporting of object with non-uv textures, we warn the user of the this fact since non-uv textures are not supported by NIF and are ignored

## Fixes Known Issues
* Unable to export an object with non-uv textures without either deleting the textures or first creating a UV-map for them.
* Updated NifError to NifLog.warn, because nothing here should prevent you from exporting your object so long as the user is aware of what is happening.
* The messages themselves were updated to be more helpful.

## Documentation
None

## Testing
You can now export blender's default object.

### Manual
* Open Blender
* File -> Export -> NetImmerse/Gamebryo
* See warnings and your untitled.nif where you asked it to be.

### Automated
None

## Additional Information
None