### PR TITLE
Submodules not getting included by makezip.bat

### DIFF
--- a/install/makezip.sh
+++ b/install/makezip.sh
@@ -12,9 +12,9 @@ cd $DIR
 mkdir ${DIR}/temp
 
 cd ${DIR}/temp
-cp -r ${ROOT}/io_scene_nif/ .
+cp -r ${ROOT}/io_scene_nif .
 mkdir io_scene_nif/modules
-cp -r ${ROOT}/pyffi/pyffi/ io_scene_nif/modules
+cp -r ${ROOT}/pyffi/pyffi io_scene_nif/modules
 cp ${ROOT}/pyffi/*.rst io_scene_nif/modules/pyffi
 rm -rf io_scene_nif/modules/pyffi/formats/cgf
 rm -rf io_scene_nif/modules/pyffi/formats/dae


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Some (most?) versions of cp when given a trailing slash on a source directory will copy the contents of the directory instead of the directory itself. The script expects the latter.

## Fixes Known Issues
n\a

## Documentation
n\a

## Testing
Initial install and export

### Manual
- Manually tested that files are included.
- Verified that pyffi package is included.
- Verified that installation of plugin is successful.
- Export successfully

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information


