### PR TITLE
Fix #264, import and export Morrowind collision nodes properly

### DIFF
--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -871,7 +871,8 @@ class NifExport(NifCommon):
             parent_block.add_child(node)
             node.flags = 0x0003 # default
             self.objecthelper.set_object_matrix(b_obj, 'localspace', node)
-            self.objecthelper.mesh_helper.export_tri_shapes(b_obj, 'none', node)
+            for child in b_obj.children:
+                self.objecthelper.export_node(child, 'localspace', node, None)
 
         elif NifOp.props.game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM'):
 

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -870,7 +870,7 @@ class NifExport(NifCommon):
             node = self.objecthelper.create_block("RootCollisionNode", b_obj)
             parent_block.add_child(node)
             node.flags = 0x0003 # default
-            self.set_object_matrix(b_obj, 'localspace', node)
+            self.objecthelper.set_object_matrix(b_obj, 'localspace', node)
             self.objecthelper.mesh_helper.export_tri_shapes(b_obj, 'none', node)
 
         elif NifOp.props.game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM'):

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -427,6 +427,9 @@ class NifImport(NifCommon):
                         b_obj = self.import_empty(niBlock)
                     else:
                         b_obj = self.boundhelper.import_bounding_box(niBlock)
+
+                    if isinstance(niBlock, NifFormat.RootCollisionNode):
+                        b_obj.game.collision_bounds_type = 'TRIANGLE_MESH'
                     geom_group = []
                 else:
                     # node groups geometries, so import it as a mesh

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -683,7 +683,7 @@ class NifImport(NifCommon):
         # if name is empty, create something non-empty
         if not niName:
             if isinstance(niBlock, NifFormat.RootCollisionNode):
-                niName = "collision"
+                niName = "RootCollisionNode"
             else:
                 niName = "noname"
         

--- a/io_scene_nif/objectsys/object_export.py
+++ b/io_scene_nif/objectsys/object_export.py
@@ -700,20 +700,21 @@ class MeshHelper():
             # fill in the NiTriShape's non-trivial values
             if isinstance(parent_block, NifFormat.RootCollisionNode):
                 trishape.name = ""
-            elif not trishape_name:
-                if parent_block.name:
-                    trishape.name = "Tri " + parent_block.name.decode()
+            else:
+                if not trishape_name:
+                    if parent_block.name:
+                        trishape.name = "Tri " + parent_block.name.decode()
+                    else:
+                        trishape.name = "Tri " + b_obj.name.decode()
                 else:
-                    trishape.name = "Tri " + b_obj.name.decode()
-            else:
-                trishape.name = trishape_name
+                    trishape.name = trishape_name
 
-            # multimaterial meshes: add material index
-            # (Morrowind's child naming convention)
-            if len(mesh_materials) > 1:
-                trishape.name = trishape.name.decode() + ":%i" % materialIndex
-            else:
-                trishape.name = self.nif_export.objecthelper.get_full_name(trishape.name)
+                # multimaterial meshes: add material index
+                # (Morrowind's child naming convention)
+                if len(mesh_materials) > 1:
+                    trishape.name = trishape.name.decode() + ":%i" % materialIndex
+                else:
+                    trishape.name = self.nif_export.objecthelper.get_full_name(trishape.name)
 
             #Trishape Flags...
             if (b_obj.type == 'MESH') and (b_obj.niftools.objectflags != 0):


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Basically, there was code to differentiate between a normal node and a RootCollisionNode, a specific node type just for Morrowind. This code was never actually used, though. It required that the name of the node be RootCollisionNode to properly export it, but the importer called it instead just "collision". Fixing the name showed how broken the exporter code was.

The fixes applied here are probably suboptimal, but it certainly works. I'd imagine this should be refactored and handled by the collision node helpers. However, that's not something I at all understand how to do.
## Fixes Known Issues
#264 

## Documentation
[Overview of updates to documentation]

## Testing
I tried this on static meshes from the Morrowind CS. I did not try animations or things with more complicated collisions.

### Manual
Import and export a stock mesh without changing anything, and check them both in NifSkope.

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]