### PR TITLE
Add fps variable to Animationhelper class

### DIFF
--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -50,6 +50,7 @@ class AnimationHelper():
         self.object_animation = ObjectAnimation(parent)
         self.material_animation = MaterialAnimation(parent)
         self.armature_animation = ArmatureAnimation(parent)
+        self.fps = 30
     
 
     def import_kf_root(self, kf_root, root):
@@ -206,6 +207,7 @@ class AnimationHelper():
                 lowest_diff = diff
                 fps = test_fps
         NifLog.info("Animation estimated at %i frames per second." % fps)
+        self.fps = 30.0
         return fps
 
     def store_animation_data(self, rootBlock):

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -207,7 +207,7 @@ class AnimationHelper():
                 lowest_diff = diff
                 fps = test_fps
         NifLog.info("Animation estimated at %i frames per second." % fps)
-        self.fps = 30.0
+        self.fps = fps
         return fps
 
     def store_animation_data(self, rootBlock):

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -137,6 +137,12 @@ class NifImport(NifCommon):
             NifLog.info("Importing data")
             # calculate and set frames per second
             if NifOp.props.animation:
+                #PG - FPS likely could only exist as a member of the animation classes. In this
+                #     edit, the class currently refers to "self.fps" to read off the fps, but
+                #     it didn't exist. It is now added as a member. Last function using FPS here
+                #     is the morph controller. When that is removed, this can just be called on
+                #     the class to set the FPS in it and to set the FPS of the scene without
+                #     needing to store it.
                 self.fps = self.animationhelper.get_frames_per_second(
                     self.data.roots
                     + (self.kfdata.roots if self.kfdata else []))


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Code was moved from main nif_import file without fixing the references to 'self.fps' that no longer applied. This adds fps varriable to the class and sets it in the fps calculation, as well as still returning it. main nif_import file still needs its own fps for now, since some code yet to move refers to it.

## Fixes Known Issues
error on .kf import for reference to non-existant variable



