### PR TITLE
New bone system (no extra matrices) & animation support

### DIFF
--- a/io_scene_nif/__init__.py
+++ b/io_scene_nif/__init__.py
@@ -103,6 +103,7 @@ def menu_func_import(self, context):
 # noinspection PyUnusedLocal
 def menu_func_export(self, context):
     self.layout.operator(operators.nif_export_op.NifExportOperator.bl_idname, text="NetImmerse/Gamebryo (.nif)")
+    # self.layout.operator(operators.kf_export_op.KfExportOperator.bl_idname, text="NetImmerse/Gamebryo (.kf)")
 
 
 def register():

--- a/io_scene_nif/io/egm.py
+++ b/io_scene_nif/io/egm.py
@@ -55,7 +55,7 @@ class EGMFile():
         # open keyframe file for binary reading
         with open(file_path, "rb") as egm_stream:
             # check if nif file is valid
-            egm_file.inspect_version_only(egm_stream)
+            egm_file.inspect_quick(egm_stream)
             if egm_file.version >= 0:
                 # it is valid, so read the file
                 NifLog.info("EGM file version: {0}".format(egm_file.version, "x"))

--- a/io_scene_nif/io/egm.py
+++ b/io_scene_nif/io/egm.py
@@ -42,7 +42,7 @@ from pyffi.formats.egm import EgmFormat
 from io_scene_nif.utility.nif_logging import NifLog
 from io_scene_nif.utility.nif_utils import NifError
 
-class EGMFile():
+class EGMFile:
     """Load and save a FaceGen Egm file"""
 
     @staticmethod

--- a/io_scene_nif/io/kf.py
+++ b/io_scene_nif/io/kf.py
@@ -42,7 +42,7 @@ from pyffi.formats.nif import NifFormat
 from io_scene_nif.utility.nif_logging import NifLog
 from io_scene_nif.utility.nif_utils import NifError
 
-class KFFile():
+class KFFile:
     """Class to load and save a NifFile"""
     
     @staticmethod

--- a/io_scene_nif/io/nif.py
+++ b/io_scene_nif/io/nif.py
@@ -42,7 +42,7 @@ from pyffi.formats.nif import NifFormat
 from io_scene_nif.utility.nif_logging import NifLog
 from io_scene_nif.utility.nif_utils import NifError
 
-class NifFile():
+class NifFile:
     """Class to load and save a NifFile"""
     
     @staticmethod

--- a/io_scene_nif/kf_import.py
+++ b/io_scene_nif/kf_import.py
@@ -79,5 +79,5 @@ class KfImport(NifCommon):
             # calculate and set frames per second
             self.animationhelper.set_frames_per_second( kfdata.roots )
             for kf_root in kfdata.roots:
-                self.animationhelper.import_kf_standalone( kf_root, b_armature, bind_data )
+                self.animationhelper.armature_animation.import_kf_standalone( kf_root, b_armature, bind_data )
         return {'FINISHED'}

--- a/io_scene_nif/kf_import.py
+++ b/io_scene_nif/kf_import.py
@@ -69,6 +69,8 @@ class KfImport(NifCommon):
         bind_data = armature.get_bind_data(b_armature)
         for kf_file in kf_files:
             kfdata = KFFile.load_kf(kf_file)
+            #the axes used for bone correction depend on the nif version
+            armature.set_bone_correction_from_version(kfdata.version)
             # use pyffi toaster to scale the tree
             toaster = pyffi.spells.nif.NifToaster()
             toaster.scale = NifOp.props.scale_correction_import

--- a/io_scene_nif/kf_import.py
+++ b/io_scene_nif/kf_import.py
@@ -66,7 +66,7 @@ class KfImport(NifCommon):
             raise nif_utils.NifError("No armature was found in scene, can not import KF animation!")
         
         #the axes used for bone correction depend on the armature in our scene
-        armature.set_bone_orientation(b_armature.data.niftools_armature.axis_forward, b_armature.data.niftools_armature.axis_up)
+        armature.set_bone_orientation(b_armature.data.niftools.axis_forward, b_armature.data.niftools.axis_up)
         
         #get nif space bind pose of armature here for all anims
         bind_data = armature.get_bind_data(b_armature)

--- a/io_scene_nif/kf_import.py
+++ b/io_scene_nif/kf_import.py
@@ -40,7 +40,7 @@
 from io_scene_nif.nif_common import NifCommon
 from io_scene_nif.io.kf import KFFile
 from io_scene_nif.modules import armature
-from io_scene_nif.modules.animation.animation_import import AnimationHelper
+from io_scene_nif.modules.animation.animation_import import Animation
 from io_scene_nif.utility.nif_global import NifOp
 from io_scene_nif.utility import nif_utils
 import pyffi.spells.nif.fix
@@ -54,7 +54,7 @@ class KfImport(NifCommon):
         NifCommon.__init__(self, operator)
         
         # Helper systems
-        self.animationhelper = AnimationHelper(parent=self)
+        self.animationhelper = Animation(parent=self)
              
     def execute(self):
         """Main import function."""

--- a/io_scene_nif/kf_import.py
+++ b/io_scene_nif/kf_import.py
@@ -65,12 +65,13 @@ class KfImport(NifCommon):
         if not b_armature:
             raise nif_utils.NifError("No armature was found in scene, can not import KF animation!")
         
+        #the axes used for bone correction depend on the armature in our scene
+        armature.set_bone_orientation(b_armature.data.niftools_armature.axis_forward, b_armature.data.niftools_armature.axis_up)
+        
         #get nif space bind pose of armature here for all anims
         bind_data = armature.get_bind_data(b_armature)
         for kf_file in kf_files:
             kfdata = KFFile.load_kf(kf_file)
-            #the axes used for bone correction depend on the nif version
-            armature.set_bone_correction_from_version(kfdata.version)
             # use pyffi toaster to scale the tree
             toaster = pyffi.spells.nif.NifToaster()
             toaster.scale = NifOp.props.scale_correction_import

--- a/io_scene_nif/modules/animation/animation_export.py
+++ b/io_scene_nif/modules/animation/animation_export.py
@@ -221,7 +221,7 @@ class AnimationHelper():
                 raise nif_utils.NifError("Incomplete ROT key set"+bonestr+" for action "+action.name)
             else:
                 for frame, quat in self.iter_frame_key(quaternions, mathutils.Quaternion):
-                    quat = nif_utils.export_keymat(bind_rot, quat.to_matrix().to_4x4(), bone).to_quaternion()
+                    quat = armature.export_keymat(bind_rot, quat.to_matrix().to_4x4(), bone).to_quaternion()
                     quat_curve.append( (frame, quat) )
                 
         if eulers:
@@ -229,7 +229,7 @@ class AnimationHelper():
                 raise nif_utils.NifError("Incomplete Euler key set"+bonestr+" for action "+action.name)
             else:
                 for frame, euler in self.iter_frame_key(eulers, mathutils.Euler):
-                    euler = nif_utils.export_keymat(bind_rot, euler.to_matrix().to_4x4(), bone).to_euler("XYZ", euler)
+                    euler = armature.export_keymat(bind_rot, euler.to_matrix().to_4x4(), bone).to_euler("XYZ", euler)
                     euler_curve.append( (frame, euler) )
                     
         if translations:
@@ -237,7 +237,7 @@ class AnimationHelper():
                 raise nif_utils.NifError("Incomplete LOC key set"+bonestr+" for action "+action.name)
             else:
                 for frame, trans in self.iter_frame_key(translations, mathutils.Vector):
-                    trans = nif_utils.export_keymat(bind_rot, mathutils.Matrix.Translation(trans), bone).to_translation() + bind_trans
+                    trans = armature.export_keymat(bind_rot, mathutils.Matrix.Translation(trans), bone).to_translation() + bind_trans
                     trans_curve.append( (frame, trans) )
                     
         # finally we can export the data calculated above

--- a/io_scene_nif/modules/animation/animation_export.py
+++ b/io_scene_nif/modules/animation/animation_export.py
@@ -64,7 +64,7 @@ class AnimationHelper():
         kfc.frequency = 1.0
         kfc.phase = 0.0
         if not start_frame and not stop_frame:
-            start_frame, stop_frame = fcurves[0].range()
+            start_frame, stop_frame = exp_fcurves[0].range()
         kfc.start_time = start_frame / self.fps
         kfc.stop_time = stop_frame / self.fps
 

--- a/io_scene_nif/modules/animation/animation_export.py
+++ b/io_scene_nif/modules/animation/animation_export.py
@@ -48,7 +48,7 @@ from io_scene_nif.utility.nif_logging import NifLog
 from io_scene_nif.utility.nif_global import NifOp
 
     
-class AnimationHelper():
+class Animation:
     
     def __init__(self, parent):
         self.nif_export = parent
@@ -379,7 +379,7 @@ class AnimationHelper():
         return textextra
     
     
-class TextureAnimation():
+class TextureAnimation:
     
     def __init__(self, parent):
         self.nif_export = parent
@@ -424,7 +424,7 @@ class TextureAnimation():
                 %fliptxt.name)
         flip.delta = (flip.stop_time - flip.start_time) / count
 
-class MaterialAnimation():
+class MaterialAnimation:
     
     def __init__(self, parent):
         self.nif_export = parent
@@ -551,7 +551,7 @@ class MaterialAnimation():
             n_geom.add_controller(n_uvctrl)
             
             
-class ObjectAnimation():
+class ObjectAnimation:
         
     def __init__(self, parent):
         self.nif_export = parent

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -488,7 +488,14 @@ class ArmatureAnimation():
         kfd = None
         
         # B-spline curve import
-        if isinstance(kfc, (NifFormat.NiBSplineInterpolator, NifFormat.NiBSplineCompTransformInterpolator)):
+        if isinstance(kfc, NifFormat.NiBSplineInterpolator):
+            # used by WLP2 (tiger.kf), but only for non-LocRotScale data
+            # eg. bone stretching - see controlledblock.get_variable_1()
+            # do not support this for now, no good representation in Blender
+            if isinstance(kfc, NifFormat.NiBSplineCompFloatInterpolator):
+                # pyffi lacks support for this, but the following gets float keys
+                # keys = list(kfc._getCompKeys(kfc.offset, 1, kfc.bias, kfc.multiplier))
+                return
             times = list(kfc.get_times())
             # just do these temp steps to avoid generating empty fcurves down the line
             trans_temp = [mathutils.Vector(tup) for tup in kfc.get_translations()]

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -609,14 +609,14 @@ class ArmatureAnimation():
                 fcurves = create_fcurves(b_action, "rotation_euler", range(3), bone_name)
                 for t, val in eulers:
                     euler = mathutils.Euler( val )
-                    key = nif_utils.import_keymat(niBone_bind_rot_inv, euler.to_matrix().to_4x4() ).to_euler()
+                    key = armature.import_keymat(niBone_bind_rot_inv, euler.to_matrix().to_4x4() ).to_euler()
                     self.nif_import.animationhelper.add_key(fcurves, t, key, interp_rot)
             elif rotations:
                 NifLog.debug('Rotation keys...(quaternions)')
                 fcurves = create_fcurves(b_action, "rotation_quaternion", range(4), bone_name)
                 for t, val in rotations:
                     quat = mathutils.Quaternion([val.w, val.x, val.y, val.z])
-                    key = nif_utils.import_keymat(niBone_bind_rot_inv, quat.to_matrix().to_4x4() ).to_quaternion()
+                    key = armature.import_keymat(niBone_bind_rot_inv, quat.to_matrix().to_4x4() ).to_quaternion()
                     self.nif_import.animationhelper.add_key(fcurves, t, key, interp_rot)
             
             if scales:
@@ -631,7 +631,7 @@ class ArmatureAnimation():
                 fcurves = create_fcurves(b_action, "location", range(3), bone_name)
                 for t, val in translations:
                     vec = mathutils.Vector([val.x, val.y, val.z])
-                    key = nif_utils.import_keymat(niBone_bind_rot_inv, mathutils.Matrix.Translation(vec - niBone_bind_trans)).to_translation()
+                    key = armature.import_keymat(niBone_bind_rot_inv, mathutils.Matrix.Translation(vec - niBone_bind_trans)).to_translation()
                     self.nif_import.animationhelper.add_key(fcurves, t, key, interp_loc)
             #get extrapolation from kfc and set it to fcurves
             if any( (eulers, rotations, scales, translations) ):

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -449,7 +449,7 @@ class ArmatureAnimation():
             bone_name = armature.get_bone_name_for_blender( controlledblock.target_name )
             # import bone priority
             b_bone = b_armature_obj.data.bones[bone_name]
-            b_bone.niftools_bone.bonepriority = controlledblock.priority
+            b_bone.niftools.bonepriority = controlledblock.priority
             # import animation
             if bone_name in bind_data:
                 niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans = bind_data[bone_name]

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -63,46 +63,6 @@ def interpolate(x_out, x_in, y_in):
         y_out.append(y_in[i] + slopes[i] * (x - x_in[i]) )
     return y_out
 
-
-def create_fcurves(action, dtype, drange, bonename = None):
-    """
-    Create fcurves in action for desired conditions.
-    """
-    # armature pose bone animation
-    if bonename:
-        return [action.fcurves.new(data_path = 'pose.bones["'+bonename+'"].'+dtype, index = i, action_group = bonename) for i in drange]
-    else:
-        # Object animation (non-skeletal)
-        # any() is intended here, as the fcurve should be lumped into the "LocRotScale" action_group if it is any of the given subtypes. It can never be all at once.
-        # nb. "rotation" catches both rotation_euler and rotation_quaternion
-        if any(subtype in dtype for subtype in ("rotation", "location", "scale")):
-            action_group = "LocRotScale"
-        # Non-transformaing animations (eg. visibility or material anims) use no action groups
-        else:
-            action_group = ""
-        return [action.fcurves.new(data_path = dtype, index = i, action_group = action_group) for i in drange]
-        
-    
-def get_interp_mode(kf_element, ):
-    """
-    Get an appropriate interpolation mode for blender's fcurves from the KF interpolation mode
-    """
-    
-    ### TODO [animation] join / make compatible with get_b_interp_from_n_interp?
-    
-    #rotation mode interpolation
-    if isinstance(kf_element, NifFormat.NiKeyframeData):
-        if kf_element.rotation_type in (NifFormat.KeyType.LINEAR_KEY, NifFormat.KeyType.XYZ_ROTATION_KEY):
-            return "LINEAR"
-        else:
-            return "QUAD"
-    #scale or translation 
-    else:
-        if kf_element.interpolation == NifFormat.KeyType.LINEAR_KEY:
-            return "LINEAR"
-        else:
-            return "QUAD"
-    
 class AnimationHelper():
     
     def __init__(self, parent):
@@ -114,7 +74,7 @@ class AnimationHelper():
         self.fps = 30
     
     def get_b_interp_from_n_interp(self, n_ipol):
-        if n_ipol == NifFormat.KeyType.LINEAR_KEY:
+        if n_ipol in (NifFormat.KeyType.LINEAR_KEY, NifFormat.KeyType.XYZ_ROTATION_KEY):
             return "LINEAR"
         elif n_ipol == NifFormat.KeyType.QUADRATIC_KEY:
             return "BEZIER"
@@ -125,6 +85,9 @@ class AnimationHelper():
         return "BEZIER"
         
     def create_action(self, b_obj, action_name):
+        """
+        Create or retrieve action and set it as active on the object.
+        """
         #could probably skip this test and create always
         if not b_obj.animation_data:
             b_obj.animation_data_create()
@@ -135,6 +98,26 @@ class AnimationHelper():
         #set as active action on object
         b_obj.animation_data.action = b_action
         return b_action
+    
+    def create_fcurves(self, action, dtype, drange, flags, bonename = None):
+        """
+        Create fcurves in action for desired conditions.
+        """
+        # armature pose bone animation
+        if bonename:
+            fcurves = [action.fcurves.new(data_path = 'pose.bones["'+bonename+'"].'+dtype, index = i, action_group = bonename) for i in drange]
+        else:
+            # Object animation (non-skeletal)
+            # any() is intended here, as the fcurve should be lumped into the "LocRotScale" action_group if it is any of the given subtypes. It can never be all at once.
+            # nb. "rotation" catches both rotation_euler and rotation_quaternion
+            if any(subtype in dtype for subtype in ("rotation", "location", "scale")):
+                action_group = "LocRotScale"
+            # Non-transformaing animations (eg. visibility or material anims) use no action groups
+            else:
+                action_group = ""
+            fcurves = [action.fcurves.new(data_path = dtype, index = i, action_group = action_group) for i in drange]
+        self.set_extrapolation(flags, fcurves)
+        return fcurves
     
     # TODO [animation]: Is there a better way to this than return a string,
     #                   since handling requires different code per type?
@@ -168,33 +151,6 @@ class AnimationHelper():
         for fcurve, k in zip(fcurves, key):
             fcurve.keyframe_points.insert(frame, k).interpolation = interp
         
-    def import_kf_standalone(self, kf_root, b_armature_obj, bind_data):
-        """
-        Import a kf animation. Needs a suitable armature in blender scene.
-        """
-
-        NifLog.info("Importing KF tree")
-
-        # check that this is an Oblivion style kf file
-        if not isinstance(kf_root, NifFormat.NiControllerSequence):
-            raise nif_utils.NifError("non-Oblivion .kf import not supported")
-
-        # import text keys
-        self.import_text_keys(kf_root)
-        
-        self.create_action(b_armature_obj, kf_root.name.decode() )
-        # go over all controlled blocks (NiKeyframeController)
-        for controlledblock in kf_root.controlled_blocks:
-            # get bone name
-            bone_name = armature.get_bone_name_for_blender( controlledblock.target_name )
-            # import bone priority
-            b_bone = b_armature_obj.data.bones[bone_name]
-            b_bone.niftools_bone.bonepriority = controlledblock.priority
-            # import animation
-            if bone_name in bind_data:
-                niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans = bind_data[bone_name]
-                self.armature_animation.import_keyframe_controller(controlledblock.controller, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans)
-    
     # import animation groups
     def import_text_keys(self, niBlock):
         """Stores the text keys that define animation start and end in a text
@@ -257,7 +213,7 @@ class AnimationHelper():
         lowest_diff = sum(abs(int(time * fps + 0.5) - (time * fps))
                           for time in key_times)
         # for test_fps in range(1,120): #disabled, used for testing
-        for test_fps in [20, 24, 25, 35]:
+        for test_fps in [20, 24, 25, 30, 35]:
             diff = sum(abs(int(time * test_fps + 0.5)-(time * test_fps))
                        for time in key_times)
             if diff < lowest_diff:
@@ -267,76 +223,6 @@ class AnimationHelper():
         self.fps = fps
         bpy.context.scene.render.fps = fps
         bpy.context.scene.frame_set(0)
-    
-    def import_object_animation(self, niBlock, b_obj):
-        """
-        Load animation attached to (Scene Root) object.
-        Becomes the object level animation of the object.
-        """
-        
-        # TODO: remove code duplication with import_keyframe_controller
-        kfc = nif_utils.find_controller(niBlock, NifFormat.NiKeyframeController)
-        if not kfc:
-            # no animation data: do nothing
-            return
-
-        if kfc.interpolator:
-            if isinstance(kfc.interpolator, NifFormat.NiBSplineInterpolator):
-                kfd = None # not supported yet so avoids fatal error - should be kfc.interpolator.spline_data when spline data is figured out.
-            else:
-                kfd = kfc.interpolator.data
-        else:
-            kfd = kfc.data
-
-        if not kfd:
-            # no animation data: do nothing
-            return
-
-        # denote progress
-        NifLog.info("Animation")
-        NifLog.info("Importing animation data for {0}".format(b_obj.name))
-        assert(isinstance(kfd, NifFormat.NiKeyframeData))
-
-        #get the interpolation modes
-        interp_rot = get_interp_mode(kfd)
-        interp_loc = get_interp_mode(kfd.translations)
-        interp_scale = get_interp_mode(kfd.scales)
-        
-        b_obj_action = self.create_action(b_obj, b_obj.name + "-Anim" )
-
-        if kfd.scales.keys:
-            NifLog.debug('Scale keys...')
-            fcurves = create_fcurves(b_obj_action, "scale", range(3))
-            for key in kfd.scales.keys:
-                v = (key.value, key.value, key.value)
-                self.add_key(fcurves, key.time, v, interp_scale)
-            
-        # detect the type of rotation keys
-        if kfd.rotation_type == 4:
-            NifLog.debug('Rotation keys...(eulers)')
-            b_obj.rotation_mode = "XYZ"
-            #Eulers are a bit different here, we can import them regardless of their timing
-            #because they need no correction math in object space
-            fcurves = create_fcurves(b_obj_action, "rotation_euler", range(3))
-            keys = (kfd.xyz_rotations[0].keys, kfd.xyz_rotations[1].keys, kfd.xyz_rotations[2].keys)
-            for fcu, keys_dim in zip(fcurves, keys):
-                for key in keys_dim:
-                    self.add_key((fcu, ), key.time, (key.value,), interp_rot)
-        # uses quaternions
-        elif kfd.quaternion_keys:
-            NifLog.debug('Rotation keys...(quaternions)')
-            b_obj.rotation_mode = "QUATERNION"
-            fcurves = create_fcurves(b_obj_action, "rotation_quaternion", range(4))
-            for key in kfd.quaternion_keys:
-                v = (key.value.w, key.value.x, key.value.y, key.value.z)
-                self.add_key(fcurves, key.time, v, interp_rot)
-
-        if kfd.translations.keys:
-            NifLog.debug('Translation keys...')
-            fcurves = create_fcurves(b_obj_action, "location", range(3))
-            for key in kfd.translations.keys:
-                v = (key.value.x, key.value.y, key.value.z)
-                self.add_key(fcurves, key.time, v, interp_rot)
 
 class ObjectAnimation():
     
@@ -353,11 +239,9 @@ class ObjectAnimation():
         
         b_obj_action = self.nif_import.animationhelper.create_action( b_obj, b_obj.name + "-Anim")
 
-        fcurves = create_fcurves(b_obj_action, "hide", (0,))
+        fcurves = self.nif_import.animationhelper.create_fcurves(b_obj_action, "hide", (0,), n_vis_ctrl.flags)
         for key in n_vis_ctrl.data.keys:
             self.nif_import.animationhelper.add_key(fcurves, key.time, (key.value, ), "CONSTANT")
-        #get extrapolation from flags and set it to fcurves
-        self.nif_import.animationhelper.set_extrapolation(n_vis_ctrl.flags, fcurves)
 
     def morph_mesh(self, b_mesh, baseverts, morphverts, v_map):
         """Transform a mesh to be in the shape given by morphverts."""
@@ -421,12 +305,12 @@ class ObjectAnimation():
                     # TODO [anim] can we create the fcurve manually - does not seem to work here?
                     # as b_obj.data.shape_keys.animation_data is read-only
                     
+                    # FYI shape_key = b_mesh.shape_keys.key_blocks[-1]
                     # set keyframes
                     for key in morphdata.keys:
-                        bpy.context.scene.frame_set( int(key.time * fps) )
-                        b_mesh.shape_keys.key_blocks[-1].value = key.value
-                        b_mesh.shape_keys.key_blocks[-1].keyframe_insert(data_path="value")
-                        
+                        shape_key.value = key.value
+                        shape_key.keyframe_insert(data_path="value", frame=round(key.time * fps))
+                    
                     fcurves = (b_obj.data.shape_keys.animation_data.action.fcurves[-1], )
                     # set extrapolation to fcurves
                     self.nif_import.animationhelper.set_extrapolation(morphCtrl.flags, fcurves)
@@ -468,50 +352,32 @@ class MaterialAnimation():
         """Import material animation data for given geometry."""
         if not NifOp.props.animation:
             return
-
-        self.import_material_alpha_controller(b_material, n_geom)
-        self.import_material_color_controller(
-            b_material=b_material,
-            b_channel="niftools.ambient_color",
-            n_geom=n_geom,
-            n_target_color=NifFormat.TargetColor.TC_AMBIENT)
-        self.import_material_color_controller(
-            b_material=b_material,
-            b_channel="diffuse_color",
-            n_geom=n_geom,
-            n_target_color=NifFormat.TargetColor.TC_DIFFUSE)
-        self.import_material_color_controller(
-            b_material=b_material,
-            b_channel="specular_color",
-            n_geom=n_geom,
-            n_target_color=NifFormat.TargetColor.TC_SPECULAR)
+        n_material = nif_utils.find_property(n_geom, NifFormat.NiMaterialProperty)
+        if n_material:
+            self.import_material_alpha_controller(b_material, n_material)
+            for b_channel, n_target_color in (("niftools.ambient_color", NifFormat.TargetColor.TC_AMBIENT), 
+                                              ("diffuse_color", NifFormat.TargetColor.TC_DIFFUSE),
+                                              ("specular_color", NifFormat.TargetColor.TC_SPECULAR)):
+                self.import_material_color_controller(b_material, n_material, b_channel, n_target_color)
+            
         self.import_material_uv_controller(b_material, n_geom)
         
-    def import_material_alpha_controller(self, b_material, n_geom):
+    def import_material_alpha_controller(self, b_material, n_material):
         # find alpha controller
-        n_matprop = nif_utils.find_property(n_geom, NifFormat.NiMaterialProperty)
-        if not n_matprop:
-            return
-        n_alphactrl = nif_utils.find_controller(n_matprop,
-                                           NifFormat.NiAlphaController)
+        n_alphactrl = nif_utils.find_controller(n_material, NifFormat.NiAlphaController)
         if not(n_alphactrl and n_alphactrl.data):
             return
         NifLog.info("Importing alpha controller")
         
         b_mat_action = self.nif_import.animationhelper.create_action( b_material, "MaterialAction")
-        fcurves = create_fcurves(b_mat_action, "alpha", (0,))
+        fcurves = self.nif_import.animationhelper.create_fcurves(b_mat_action, "alpha", (0,), n_alphactrl.flags)
         interp = self.nif_import.animationhelper.get_b_interp_from_n_interp( n_alphactrl.data.data.interpolation)
-        self.nif_import.animationhelper.set_extrapolation(n_alphactrl.flags, fcurves)
         for key in n_alphactrl.data.data.keys:
             self.nif_import.animationhelper.add_key(fcurves, key.time, (key.value, ), interp)
 
-    def import_material_color_controller(
-        self, b_material, b_channel, n_geom, n_target_color):
+    def import_material_color_controller(self, b_material, n_material, b_channel, n_target_color):
         # find material color controller with matching target color
-        n_matprop = nif_utils.find_property(n_geom, NifFormat.NiMaterialProperty)
-        if not n_matprop:
-            return
-        for ctrl in n_matprop.get_controllers():
+        for ctrl in n_material.get_controllers():
             if isinstance(ctrl, NifFormat.NiMaterialColorController):
                 if ctrl.get_target_color() == n_target_color:
                     n_matcolor_ctrl = ctrl
@@ -522,17 +388,15 @@ class MaterialAnimation():
         # import data as curves
         b_mat_action = self.nif_import.animationhelper.create_action( b_material, "MaterialAction")
         
-        fcurves = create_fcurves(b_mat_action, b_channel, range(3))
+        fcurves = self.nif_import.animationhelper.create_fcurves(b_mat_action, b_channel, range(3), n_matcolor_ctrl.flags)
         interp = self.nif_import.animationhelper.get_b_interp_from_n_interp( n_matcolor_ctrl.data.data.interpolation)
-        self.nif_import.animationhelper.set_extrapolation(n_matcolor_ctrl.flags, fcurves)
         for key in n_matcolor_ctrl.data.data.keys:
             self.nif_import.animationhelper.add_key(fcurves, key.time, key.value.as_list(), interp)
 
     def import_material_uv_controller(self, b_material, n_geom):
         """Import UV controller data."""
         # search for the block
-        n_ctrl = nif_utils.find_controller(n_geom,
-                                      NifFormat.NiUVController)
+        n_ctrl = nif_utils.find_controller(n_geom, NifFormat.NiUVController)
         if not(n_ctrl and n_ctrl.data):
             return
         NifLog.info("Importing UV controller")
@@ -547,13 +411,12 @@ class MaterialAnimation():
                 #so we have to repeat the import for each used tex slot
                 for i, texture_slot in enumerate(b_material.texture_slots):
                     if texture_slot:
-                        fcurves = create_fcurves(b_mat_action, "texture_slots["+str(i)+"]."+data_path, (array_ind,) )
+                        fcurves = self.nif_import.animationhelper.create_fcurves(b_mat_action, "texture_slots["+str(i)+"]."+data_path, (array_ind,), n_ctrl.flags )
                         for key in n_uvgroup.keys:
                             if "offset" in data_path:
                                 self.nif_import.animationhelper.add_key(fcurves, key.time, (-key.value, ), interp)
                             else:
                                 self.nif_import.animationhelper.add_key(fcurves, key.time, (key.value, ), interp)
-                        self.nif_import.animationhelper.set_extrapolation( n_ctrl.flags, fcurves)
                             
 
 class ArmatureAnimation():
@@ -561,117 +424,159 @@ class ArmatureAnimation():
     def __init__(self, parent):
         self.nif_import = parent
     
-    def import_keyframe_controller(self, kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans):
-        if kfc:
-            b_action = b_armature_obj.animation_data.action
-            b_pbone = b_armature_obj.pose.bones[bone_name]
-            # old style: data directly on controller
-            kfd = kfc.data
-            # new style: data via interpolator
-            kfi = kfc.interpolator
-            
-            translations = []
-            scales = []
-            rotations = []
-            eulers = []
+    def import_kf_standalone(self, kf_root, b_armature_obj, bind_data):
+        """
+        Import a kf animation. Needs a suitable armature in blender scene.
+        """
 
-            #TODO: test interpolators
-            # B-spline curve import
-            if isinstance(kfi, NifFormat.NiBSplineInterpolator):
-                times = list(kfi.get_times())
-                
-                translations = zip( times, list(kfi.get_translations()) )
-                scales = zip( times, list(kfi.get_scales()) )
-                rotations = zip( times, list(kfi.get_rotations()) )
-                
-                #TODO: get these from interpolator?
-                interp_rot = "LINEAR"
-                interp_loc = "LINEAR"
-                interp_scale = "LINEAR"
-                return
-            # next is a quick hack to make the new transform
-            # interpolator work as if it is an old style keyframe data
-            # block parented directly on the controller
-            if isinstance(kfi, NifFormat.NiTransformInterpolator):
-                kfd = kfi.data
-                # for now, in this case, ignore interpolator
-                kfi = None
-            if isinstance(kfd, NifFormat.NiKeyframeData):
-                interp_rot = get_interp_mode(kfd)
-                interp_loc = get_interp_mode(kfd.translations)
-                interp_scale = get_interp_mode(kfd.scales)
-                if kfd.rotation_type == 4:
-                    b_pbone.rotation_mode = "XYZ"
-                    # uses xyz rotation
-                    if kfd.xyz_rotations[0].keys:
-                        
-                        #euler keys need not be sampled at the same time in KFs
-                        #but we need complete key sets to do the space conversion
-                        #so perform linear interpolation to import all keys properly
-                        
-                        #get all the keys' times
-                        times_x = [key.time for key in kfd.xyz_rotations[0].keys]
-                        times_y = [key.time for key in kfd.xyz_rotations[1].keys]
-                        times_z = [key.time for key in kfd.xyz_rotations[2].keys]
-                        #the unique time stamps we have to sample all curves at
-                        times_all = sorted( set(times_x + times_y + times_z) )
-                        #the actual resampling
-                        x_r = interpolate(times_all, times_x, [key.value for key in kfd.xyz_rotations[0].keys])
-                        y_r = interpolate(times_all, times_y, [key.value for key in kfd.xyz_rotations[1].keys])
-                        z_r = interpolate(times_all, times_z, [key.value for key in kfd.xyz_rotations[2].keys])
-                    eulers = zip(times_all, zip(x_r, y_r, z_r) )
-                else:
-                    b_pbone.rotation_mode = "QUATERNION"
-                    rotations = [(key.time, key.value) for key in kfd.quaternion_keys]
+        NifLog.info("Importing KF tree")
+
+        # check that this is an Oblivion style kf file
+        if not isinstance(kf_root, NifFormat.NiControllerSequence):
+            raise nif_utils.NifError("non-Oblivion .kf import not supported")
+
+        # import text keys
+        self.nif_import.animationhelper.import_text_keys(kf_root)
+        
+        self.nif_import.animationhelper.create_action(b_armature_obj, kf_root.name.decode() )
+        # go over all controlled blocks (NiKeyframeController)
+        for controlledblock in kf_root.controlled_blocks:
+            # get bone name
+            bone_name = armature.get_bone_name_for_blender( controlledblock.target_name )
+            # import bone priority
+            b_bone = b_armature_obj.data.bones[bone_name]
+            b_bone.niftools_bone.bonepriority = controlledblock.priority
+            # import animation
+            if bone_name in bind_data:
+                niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans = bind_data[bone_name]
+                kfc = controlledblock.controller
+                if kfc:
+                    self.import_keyframe_controller(kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans)
+    
+    def import_keyframe_controller(self, kfc, b_obj, bone_name=None, niBone_bind_scale=None, niBone_bind_rot_inv=None, niBone_bind_trans=None):
+        b_action = b_obj.animation_data.action
+        
+        if bone_name:
+            b_obj = b_obj.pose.bones[bone_name]
             
-                if kfd.scales.keys:
-                    scales = [(key.time, key.value) for key in kfd.scales.keys]
-                    
-                if kfd.translations.keys:
-                    translations = [(key.time, key.value) for key in kfd.translations.keys]
-                    
-            if eulers:
-                NifLog.debug('Rotation keys...(euler)')
-                fcurves = create_fcurves(b_action, "rotation_euler", range(3), bone_name)
-                for t, val in eulers:
-                    euler = mathutils.Euler( val )
-                    key = armature.import_keymat(niBone_bind_rot_inv, euler.to_matrix().to_4x4() ).to_euler()
-                    self.nif_import.animationhelper.add_key(fcurves, t, key, interp_rot)
-            elif rotations:
-                NifLog.debug('Rotation keys...(quaternions)')
-                fcurves = create_fcurves(b_action, "rotation_quaternion", range(4), bone_name)
-                for t, val in rotations:
-                    quat = mathutils.Quaternion([val.w, val.x, val.y, val.z])
-                    key = armature.import_keymat(niBone_bind_rot_inv, quat.to_matrix().to_4x4() ).to_quaternion()
-                    self.nif_import.animationhelper.add_key(fcurves, t, key, interp_rot)
+        # old style: data directly on controller
+        kfd = kfc.data
+        # new style: data via interpolator
+        kfi = kfc.interpolator
+        
+        translations = []
+        scales = []
+        rotations = []
+        eulers = []
+
+        #TODO: test interpolators
+        # B-spline curve import
+        if isinstance(kfi, NifFormat.NiBSplineInterpolator):
+            times = list(kfi.get_times())
             
-            if scales:
-                NifLog.debug('Scale keys...')
-                fcurves = create_fcurves(b_action, "scale", range(3), bone_name)
-                for t, val in scales:
-                    key = (val, val, val)
-                    self.nif_import.animationhelper.add_key(fcurves, t, key, interp_scale)
-                        
-            if translations:
-                NifLog.debug('Translation keys...')
-                fcurves = create_fcurves(b_action, "location", range(3), bone_name)
-                for t, val in translations:
-                    vec = mathutils.Vector([val.x, val.y, val.z])
-                    key = armature.import_keymat(niBone_bind_rot_inv, mathutils.Matrix.Translation(vec - niBone_bind_trans)).to_translation()
-                    self.nif_import.animationhelper.add_key(fcurves, t, key, interp_loc)
-            #get extrapolation from kfc and set it to fcurves
-            if any( (eulers, rotations, scales, translations) ):
-                self.nif_import.animationhelper.set_extrapolation(kfc.flags, b_action.groups[bone_name].channels)
-           
+            translations = zip( times, list(kfi.get_translations()) )
+            scales = zip( times, list(kfi.get_scales()) )
+            rotations = zip( times, list(kfi.get_rotations()) )
+            
+            #TODO: get these from interpolator?
+            interp_rot = "LINEAR"
+            interp_loc = "LINEAR"
+            interp_scale = "LINEAR"
+            return
+        # next is a quick hack to make the new transform
+        # interpolator work as if it is an old style keyframe data
+        # block parented directly on the controller
+        if isinstance(kfi, NifFormat.NiTransformInterpolator):
+            kfd = kfi.data
+            # for now, in this case, ignore interpolator
+            kfi = None
+        if isinstance(kfd, NifFormat.NiKeyframeData):
+            interp_rot = self.nif_import.animationhelper.get_b_interp_from_n_interp(kfd.rotation_type)
+            interp_loc = self.nif_import.animationhelper.get_b_interp_from_n_interp(kfd.translations.interpolation)
+            interp_scale = self.nif_import.animationhelper.get_b_interp_from_n_interp(kfd.scales.interpolation)
+            if kfd.rotation_type == 4:
+                b_obj.rotation_mode = "XYZ"
+                # uses xyz rotation
+                if kfd.xyz_rotations[0].keys:
+                    
+                    #euler keys need not be sampled at the same time in KFs
+                    #but we need complete key sets to do the space conversion
+                    #so perform linear interpolation to import all keys properly
+                    
+                    #get all the keys' times
+                    times_x = [key.time for key in kfd.xyz_rotations[0].keys]
+                    times_y = [key.time for key in kfd.xyz_rotations[1].keys]
+                    times_z = [key.time for key in kfd.xyz_rotations[2].keys]
+                    #the unique time stamps we have to sample all curves at
+                    times_all = sorted( set(times_x + times_y + times_z) )
+                    #the actual resampling
+                    x_r = interpolate(times_all, times_x, [key.value for key in kfd.xyz_rotations[0].keys])
+                    y_r = interpolate(times_all, times_y, [key.value for key in kfd.xyz_rotations[1].keys])
+                    z_r = interpolate(times_all, times_z, [key.value for key in kfd.xyz_rotations[2].keys])
+                eulers = zip(times_all, zip(x_r, y_r, z_r) )
+            else:
+                b_obj.rotation_mode = "QUATERNION"
+                rotations = [(key.time, key.value) for key in kfd.quaternion_keys]
+        
+            if kfd.scales.keys:
+                scales = [(key.time, key.value) for key in kfd.scales.keys]
+                
+            if kfd.translations.keys:
+                translations = [(key.time, key.value) for key in kfd.translations.keys]
+                
+        if eulers:
+            NifLog.debug('Rotation keys...(euler)')
+            fcurves = self.nif_import.animationhelper.create_fcurves(b_action, "rotation_euler", range(3), kfc.flags, bone_name)
+            for t, val in eulers:
+                key = mathutils.Euler( val )
+                if bone_name:
+                    key = armature.import_keymat(niBone_bind_rot_inv, key.to_matrix().to_4x4() ).to_euler()
+                self.nif_import.animationhelper.add_key(fcurves, t, key, interp_rot)
+        elif rotations:
+            NifLog.debug('Rotation keys...(quaternions)')
+            fcurves = self.nif_import.animationhelper.create_fcurves(b_action, "rotation_quaternion", range(4), kfc.flags, bone_name)
+            for t, val in rotations:
+                key = mathutils.Quaternion([val.w, val.x, val.y, val.z])
+                if bone_name:
+                    key = armature.import_keymat(niBone_bind_rot_inv, key.to_matrix().to_4x4() ).to_quaternion()
+                self.nif_import.animationhelper.add_key(fcurves, t, key, interp_rot)
+        if translations:
+            NifLog.debug('Translation keys...')
+            fcurves = self.nif_import.animationhelper.create_fcurves(b_action, "location", range(3), kfc.flags, bone_name)
+            for t, val in translations:
+                key = mathutils.Vector([val.x, val.y, val.z])
+                if bone_name:
+                    key = armature.import_keymat(niBone_bind_rot_inv, mathutils.Matrix.Translation(key - niBone_bind_trans)).to_translation()
+                self.nif_import.animationhelper.add_key(fcurves, t, key, interp_loc)
+        if scales:
+            NifLog.debug('Scale keys...')
+            fcurves = self.nif_import.animationhelper.create_fcurves(b_action, "scale", range(3), kfc.flags, bone_name)
+            for t, val in scales:
+                key = (val, val, val)
+                self.nif_import.animationhelper.add_key(fcurves, t, key, interp_scale)
+
+    def import_object_animation(self, n_block, b_obj):
+        """
+        Loads an animation attached to a nif block (non-skeletal).
+        Becomes the object level animation of the blender object.
+        """
+        NifLog.debug('Importing animation for object %s'.format(b_obj.name))
+        
+        kfc = nif_utils.find_controller(n_block, NifFormat.NiKeyframeController)
+        if kfc:
+            self.nif_import.animationhelper.create_action(b_obj, b_obj.name+"-Anim" )
+            self.import_keyframe_controller(kfc, b_obj)
+        
     def import_bone_animation(self, n_block, b_armature_obj, bone_name):
         """
-        Imports an animation contained in the NIF itself.
+        Loads an animation attached to a nif block (skeletal).
+        Becomes the pose bone level animation of the blender object.
         """
         NifLog.debug('Importing animation for bone %s'.format(bone_name))
-
-        bone_bm = nif_utils.import_matrix(n_block) # base pose
-        niBone_bind_scale, niBone_bind_rot, niBone_bind_trans = nif_utils.decompose_srt(bone_bm)
-        niBone_bind_rot_inv = niBone_bind_rot.to_4x4().inverted()
+        
         kfc = nif_utils.find_controller(n_block, NifFormat.NiKeyframeController)
-                                   
-        self.import_keyframe_controller(kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans)
+        if kfc:
+            bone_bm = nif_utils.import_matrix(n_block) # base pose
+            niBone_bind_scale, niBone_bind_rot, niBone_bind_trans = nif_utils.decompose_srt(bone_bm)
+            niBone_bind_rot_inv = niBone_bind_rot.to_4x4().inverted()
+            self.import_keyframe_controller(kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans)

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -168,7 +168,7 @@ class AnimationHelper():
         for fcurve, k in zip(fcurves, key):
             fcurve.keyframe_points.insert(frame, k).interpolation = interp
         
-    def import_kf_standalone(self, kf_root, b_armature_obj, bind_data, scale_correction_import):
+    def import_kf_standalone(self, kf_root, b_armature_obj, bind_data):
         """
         Import a kf animation. Needs a suitable armature in blender scene.
         """
@@ -191,7 +191,7 @@ class AnimationHelper():
             bone_name = armature.get_bone_name_for_blender( controlledblock.target_name )
             if bone_name in bind_data:
                 niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans = bind_data[bone_name]
-                self.armature_animation.import_keyframe_controller(kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans, scale_correction_import)
+                self.armature_animation.import_keyframe_controller(kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans)
                 
 
     def import_kf_root(self, kf_root, root):
@@ -651,7 +651,7 @@ class ArmatureAnimation():
     def __init__(self, parent):
         self.nif_import = parent
     
-    def import_keyframe_controller(self, kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans, scale_correction_import):
+    def import_keyframe_controller(self, kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans):
         if kfc:
             b_action = b_armature_obj.animation_data.action
             # old style: data directly on controller
@@ -686,8 +686,6 @@ class ArmatureAnimation():
                 # for now, in this case, ignore interpolator
                 kfi = None
             if isinstance(kfd, NifFormat.NiKeyframeData):
-                #apply scale via pyffi - but it's as simple as multiplying the kf trans key with the scale scalar
-                kfd.apply_scale(scale_correction_import)
                 interp_rot = get_interp_mode(kfd)
                 interp_loc = get_interp_mode(kfd.translations)
                 interp_scale = get_interp_mode(kfd.scales)

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -266,7 +266,7 @@ class AnimationHelper():
         bpy.context.scene.render.fps = fps
         bpy.context.scene.frame_set(0)
     
-    def set_animation(self, niBlock, b_obj):
+    def import_object_animation(self, niBlock, b_obj):
         """
         Load animation attached to (Scene Root) object.
         Becomes the object level animation of the object.
@@ -636,27 +636,17 @@ class ArmatureAnimation():
             #get extrapolation from kfc and set it to fcurves
             if any( (eulers, rotations, scales, translations) ):
                 self.nif_import.animationhelper.set_extrapolation(kfc.flags, b_action.groups[bone_name].channels)
-            
-    def import_armature_animation(self, b_armature_obj):
+           
+    def import_bone_animation(self, n_block, b_armature_obj, bone_name):
         """
         Imports an animation contained in the NIF itself.
         """
-        # create an action
-        self.nif_import.animationhelper.create_action(b_armature_obj, b_armature_obj.name+"-kfAnim" )
-        # go through all armature pose bones
-        NifLog.info('Importing Animations')
-        for bone_name, b_posebone in b_armature_obj.pose.bones.items():
-            # denote progress
+        if NifOp.props.animation:
             NifLog.debug('Importing animation for bone %s'.format(bone_name))
-            niBone = self.nif_import.dict_blocks[bone_name]
 
-            bone_bm = nif_utils.import_matrix(niBone) # base pose
+            bone_bm = nif_utils.import_matrix(n_block) # base pose
             niBone_bind_scale, niBone_bind_rot, niBone_bind_trans = nif_utils.decompose_srt(bone_bm)
             niBone_bind_rot_inv = niBone_bind_rot.to_4x4().inverted()
-            
-            # get controller, interpolator, and data
-            # note: the NiKeyframeController check also includes
-            #       NiTransformController (see hierarchy!)
-            kfc = nif_utils.find_controller(niBone, NifFormat.NiKeyframeController)
+            kfc = nif_utils.find_controller(n_block, NifFormat.NiKeyframeController)
                                        
             self.import_keyframe_controller(kfc, b_armature_obj, bone_name, niBone_bind_scale, niBone_bind_rot_inv, niBone_bind_trans)

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -507,11 +507,8 @@ class ArmatureAnimation():
             scale_temp = list(kfc.get_scales())
             if scale_temp:
                 scales = zip( times, scale_temp )
-            
-            #TODO: get these from interpolator?
-            interp_rot = "LINEAR"
-            interp_loc = "LINEAR"
-            interp_scale = "LINEAR"
+            # Bsplines are Bezier curves
+            interp_rot = interp_loc = interp_scale = "BEZIER"
         else:
             # ZT2 & Fallout
             kfd = kfc.data

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -63,7 +63,7 @@ def interpolate(x_out, x_in, y_in):
         y_out.append(y_in[i] + slopes[i] * (x - x_in[i]) )
     return y_out
 
-class AnimationHelper():
+class Animation:
     
     def __init__(self, parent):
         self.nif_import = parent
@@ -225,7 +225,7 @@ class AnimationHelper():
         bpy.context.scene.render.fps = fps
         bpy.context.scene.frame_set(0)
 
-class ObjectAnimation():
+class ObjectAnimation:
     
     def __init__(self, parent):
         self.nif_import = parent

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -490,11 +490,16 @@ class ArmatureAnimation():
         # B-spline curve import
         if isinstance(kfc, (NifFormat.NiBSplineInterpolator, NifFormat.NiBSplineCompTransformInterpolator)):
             times = list(kfc.get_times())
-            
-            translations = zip( times, [mathutils.Vector(tup) for tup in kfc.get_translations()] )
-            rotations = zip( times, [mathutils.Quaternion(tup) for tup in kfc.get_rotations()] )
-            # scales import as 0, investigate later
-            # scales = zip( times, list(kfc.get_scales()) )
+            # just do these temp steps to avoid generating empty fcurves down the line
+            trans_temp = [mathutils.Vector(tup) for tup in kfc.get_translations()]
+            if trans_temp:
+                translations = zip( times, trans_temp )
+            rot_temp = [mathutils.Quaternion(tup) for tup in kfc.get_rotations()]
+            if rot_temp:
+                rotations = zip( times, rot_temp )
+            scale_temp = list(kfc.get_scales())
+            if scale_temp:
+                scales = zip( times, scale_temp )
             
             #TODO: get these from interpolator?
             interp_rot = "LINEAR"

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -311,12 +311,12 @@ class ObjectAnimation():
                         shape_key.value = key.value
                         shape_key.keyframe_insert(data_path="value", frame=round(key.time * fps))
                     
-                    fcurves = (b_obj.data.shape_keys.animation_data.action.fcurves[-1], )
-                    # set extrapolation to fcurves
-                    self.nif_import.animationhelper.set_extrapolation(morphCtrl.flags, fcurves)
-                    # get the interpolation mode
-                    interp = self.nif_import.animationhelper.get_b_interp_from_n_interp( morphdata.interpolation)
-                    # TODO [anim] set interpolation once low level access works
+                    # fcurves = (b_obj.data.shape_keys.animation_data.action.fcurves[-1], )
+                    # # set extrapolation to fcurves
+                    # self.nif_import.animationhelper.set_extrapolation(morphCtrl.flags, fcurves)
+                    # # get the interpolation mode
+                    # interp = self.nif_import.animationhelper.get_b_interp_from_n_interp( morphdata.interpolation)
+                    # # TODO [anim] set interpolation once low level access works
                         
     def import_egm_morphs(self, egmdata, b_obj, v_map, n_verts):
         """Import all EGM morphs as shape keys for blender object."""
@@ -339,7 +339,13 @@ class ObjectAnimation():
                    for i, morph in enumerate(asym_morphs)])
 
         for morphverts, keyname in morphs:
-            self.morph_mesh(b_mesh, n_verts, morphverts, v_map)
+            #convert tuples into vector here so we can simply add in morph_mesh()
+            morphvert_out = []
+            for u in morphverts:
+                v = NifFormat.Vector3()
+                v.x, v.y, v.z = u
+                morphvert_out.append(v)
+            self.morph_mesh(b_mesh, n_verts, morphvert_out, v_map)
             shape_key = b_obj.shape_key_add(keyname, from_mix=False)
 
                 

--- a/io_scene_nif/modules/animation/animation_import.py
+++ b/io_scene_nif/modules/animation/animation_import.py
@@ -107,10 +107,8 @@ class AnimationHelper():
         if bonename:
             fcurves = [action.fcurves.new(data_path = 'pose.bones["'+bonename+'"].'+dtype, index = i, action_group = bonename) for i in drange]
         else:
-            # Object animation (non-skeletal)
-            # any() is intended here, as the fcurve should be lumped into the "LocRotScale" action_group if it is any of the given subtypes. It can never be all at once.
-            # nb. "rotation" catches both rotation_euler and rotation_quaternion
-            if any(subtype in dtype for subtype in ("rotation", "location", "scale")):
+            # Object animation (non-skeletal) is lumped into the "LocRotScale" action_group
+            if dtype in ("rotation_euler", "rotation_quaternion", "location", "scale"):
                 action_group = "LocRotScale"
             # Non-transformaing animations (eg. visibility or material anims) use no action groups
             else:

--- a/io_scene_nif/modules/armature/__init__.py
+++ b/io_scene_nif/modules/armature/__init__.py
@@ -39,10 +39,6 @@ import bpy
 from bpy_extras.io_utils import axis_conversion
 from io_scene_nif.utility import nif_utils
 
-# dictionary of bones that belong to a certain armature
-# maps NIF armature name to list of NIF bone name
-DICT_ARMATURES = {}
-
 # bone animation priorities (maps NiNode name to priority number);
 # priorities are set in import_kf_root and are stored into the name
 # of a NULL constraint (for lack of something better) in

--- a/io_scene_nif/modules/armature/__init__.py
+++ b/io_scene_nif/modules/armature/__init__.py
@@ -39,13 +39,6 @@ import bpy
 from bpy_extras.io_utils import axis_conversion
 from io_scene_nif.utility import nif_utils
 
-# bone animation priorities (maps NiNode name to priority number);
-# priorities are set in import_kf_root and are stored into the name
-# of a NULL constraint (for lack of something better) in
-# import_armature
-DICT_BONE_PRIORITIES = {}
-
-
 def get_bone_name_for_blender(name):
     """Convert a bone name to a name that can be used by Blender: turns
     'Bip01 R xxx' into 'Bip01 xxx.R', and similar for L.

--- a/io_scene_nif/modules/armature/__init__.py
+++ b/io_scene_nif/modules/armature/__init__.py
@@ -107,15 +107,15 @@ def get_bone_name_for_nif(name):
         return name
     return name
 
-def set_bone_correction_from_version(version):
-    if version in (0x14020007, ):
-        # skyrim
-        from_forward = "Z"
-        from_up = "Y"
-    else:
+def set_bone_orientation(from_forward, from_up):
+    # if version in (0x14020007, ):
+        # # skyrim
+        # from_forward = "Z"
+        # from_up = "Y"
+    # else:
         # ZT2 and other old ones
-        from_forward = "X"
-        from_up = "Y"
+        # from_forward = "X"
+        # from_up = "Y"
     global correction
     global correction_inv
     correction = axis_conversion( from_forward, from_up ).to_4x4()

--- a/io_scene_nif/modules/armature/armature_export.py
+++ b/io_scene_nif/modules/armature/armature_export.py
@@ -111,14 +111,6 @@ class Armature():
             # per-node animation
             self.nif_export.animationhelper.export_keyframes(node, arm, bone)
 
-            # does bone have priority value in NULL constraint?
-            for constr in arm.pose.bones[bone.name].constraints:
-                # yes! store it for reference when creating the kf file
-                if constr.name[:9].lower() == "priority:":
-                    self.nif_export.dict_bone_priorities[
-                        armature.get_bone_name_for_nif(bone.name)
-                        ] = int(constr.name[9:])
-
         # now fix the linkage between the blocks
         for bone in bones:
             # link the bone's children to the bone

--- a/io_scene_nif/modules/armature/armature_export.py
+++ b/io_scene_nif/modules/armature/armature_export.py
@@ -52,14 +52,13 @@ class Armature():
 
     def __init__(self, parent):
         self.nif_export = parent
-        
     
     def export_bones(self, arm, parent_block):
         """Export the bones of an armature."""
         # the armature was already exported as a NiNode
         # now we must export the armature's bones
         assert( arm.type == 'ARMATURE' )
-
+        
         # find the root bones
         # list of all bones
         bones = arm.data.bones.values()

--- a/io_scene_nif/modules/armature/armature_export.py
+++ b/io_scene_nif/modules/armature/armature_export.py
@@ -120,46 +120,5 @@ class Armature():
             # if it is a root bone, link it to the armature
             if not bone.parent:
                 parent_block.add_child(bones_node[bone.name])
-                
     
-    def export_children(self, b_obj, parent_block):
-        """Export all children of blender object b_obj as children of
-        parent_block."""
-        # loop over all obj's children
-        for b_obj_child in b_obj.children:
-            # is it a regular node?
-            if b_obj_child.type in ['MESH', 'EMPTY', 'ARMATURE']:
-                if (b_obj.type != 'ARMATURE'):
-                    # not parented to an armature
-                    self.nif_export.objecthelper.export_node(b_obj_child, parent_block, b_obj_child.name)
-                else:
-                    # this object is parented to an armature
-                    # we should check whether it is really parented to the
-                    # armature using vertex weights
-                    # or whether it is parented to some bone of the armature
-                    parent_bone_name = b_obj_child.parent_bone
-                    if parent_bone_name == "":
-                        self.nif_export.objecthelper.export_node(b_obj_child, parent_block, b_obj_child.name)
-                    else:
-                        # we should parent the object to the bone instead of
-                        # to the armature
-                        # so let's find that bone!
-                        parent_bone = b_obj.data.bones[parent_bone_name]
-                        nif_bone_name = self.nif_export.objecthelper.get_full_name(parent_bone)
-                        for bone_block in self.nif_export.dict_blocks:
-                            if isinstance(bone_block, NifFormat.NiNode) and \
-                                bone_block.name.decode() == nif_bone_name:
-                                # ok, we should parent to block
-                                # instead of to parent_block
-                                # two problems to resolve:
-                                #   - blender bone matrix is not the exported
-                                #     bone matrix!
-                                #   - blender objects parented to bone have
-                                #     extra translation along the Y axis
-                                #     with length of the bone ("tail")
-                                # this is handled in the get_object_srt function
-                                self.nif_export.objecthelper.export_node(b_obj_child, bone_block, b_obj_child.name)
-                                break
-                        else:
-                            assert(False) # BUG!
    

--- a/io_scene_nif/modules/armature/armature_export.py
+++ b/io_scene_nif/modules/armature/armature_export.py
@@ -80,8 +80,8 @@ class Armature():
             # add the node and the keyframe for this bone
             node.name = self.nif_export.objecthelper.get_full_name(bone.name)
             
-            if (bone.niftools_bone.boneflags != 0):
-                node.flags = bone.niftools_bone.boneflags
+            if (bone.niftools.boneflags != 0):
+                node.flags = bone.niftools.boneflags
             else:
                 if NifOp.props.game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM'):
                     # default for Oblivion bones

--- a/io_scene_nif/modules/armature/armature_export.py
+++ b/io_scene_nif/modules/armature/armature_export.py
@@ -154,7 +154,6 @@ class Armature():
                         # so let's find that bone!
                         parent_bone = b_obj.data.bones[parent_bone_name]
                         nif_bone_name = self.nif_export.objecthelper.get_full_name(parent_bone)
-                        print(nif_bone_name)
                         for bone_block in self.nif_export.dict_blocks:
                             if isinstance(bone_block, NifFormat.NiNode) and \
                                 bone_block.name.decode() == nif_bone_name:

--- a/io_scene_nif/modules/armature/armature_export.py
+++ b/io_scene_nif/modules/armature/armature_export.py
@@ -78,7 +78,7 @@ class Armature():
             bones_node[bone.name] = node
 
             # add the node and the keyframe for this bone
-            node.name = self.nif_export.objecthelper.get_full_name(bone.name)
+            node.name = self.nif_export.objecthelper.get_full_name(bone)
             
             if (bone.niftools.boneflags != 0):
                 node.flags = bone.niftools.boneflags
@@ -152,7 +152,9 @@ class Armature():
                         # we should parent the object to the bone instead of
                         # to the armature
                         # so let's find that bone!
-                        nif_bone_name = self.nif_export.objecthelper.get_full_name(parent_bone_name)
+                        parent_bone = b_obj.data.bones[parent_bone_name]
+                        nif_bone_name = self.nif_export.objecthelper.get_full_name(parent_bone)
+                        print(nif_bone_name)
                         for bone_block in self.nif_export.dict_blocks:
                             if isinstance(bone_block, NifFormat.NiNode) and \
                                 bone_block.name.decode() == nif_bone_name:

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -138,11 +138,12 @@ class Armature():
         
     def append_armature_modifier(self, b_obj, b_armature):
         """Append an armature modifier for the object."""
-        armature_name = b_armature.name
-        b_mod = b_obj.modifiers.new(armature_name,'ARMATURE')
-        b_mod.object = b_armature
-        b_mod.use_bone_envelopes = False
-        b_mod.use_vertex_groups = True
+        if b_obj and b_armature:
+            armature_name = b_armature.name
+            b_mod = b_obj.modifiers.new(armature_name,'ARMATURE')
+            b_mod.object = b_armature
+            b_mod.use_bone_envelopes = False
+            b_mod.use_vertex_groups = True
 
     def mark_armatures_bones(self, niBlock):
         """Mark armatures and bones by peeking into NiSkinInstance blocks."""
@@ -177,7 +178,8 @@ class Armature():
             b_armature_obj = self.nif_import.selected_objects[0]
             skelroot = niBlock.find(block_name=b_armature_obj.name)
             if not skelroot:
-                raise nif_utils.NifError("nif has no armature '%s'" % b_armature_obj.name)
+                skelroot = niBlock
+                # raise nif_utils.NifError("nif has no armature '%s'" % b_armature_obj.name)
             NifLog.debug("Identified '{0}' as armature".format(skelroot.name))
             self.dict_armatures[skelroot] = []
             for bone_name in b_armature_obj.data.bones.keys():

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -66,6 +66,9 @@ class Armature():
         armature_name = n_armature.name.decode()
         b_armature_data = bpy.data.armatures.new(armature_name)
         b_armature_data.draw_type = 'STICK'
+        # set axis orientation for export
+        b_armature_data.niftools.axis_forward = NifOp.props.axis_forward
+        b_armature_data.niftools.axis_up = NifOp.props.axis_up
         b_armature_obj = self.nif_import.objecthelper.create_b_obj(n_armature, b_armature_data)
         b_armature_obj.show_x_ray = True
         
@@ -324,9 +327,9 @@ class Armature():
                 NifLog.debug("'{0}' marked as extra bone of armature '{1}'".format(bone.name, skelroot.name))
         
     def complete_bone_tree(self, bone, skelroot):
-        """Make sure that the complete hierarchy from skelroot down to bone is marked in dict_armatures.
+        """Make sure that the complete hierarchy from bone up to skelroot is marked in dict_armatures.
         """
-        # we must already have marked this one as a bone
+        # we must already have marked both as a bone
         assert skelroot in self.dict_armatures # debug
         assert bone in self.dict_armatures[skelroot] # debug
         # get the node parent, this should be marked as an armature or as a bone

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -284,22 +284,5 @@ class Armature():
         if isinstance(niBlock, NifFormat.NiNode):
             return niBlock in self.dict_armatures
         
-    def store_names(self):
-        """Stores the original, long object names so that they can be
-        re-exported. In order for this to work it is necessary to mantain the
-        imported names unaltered. Since the text buffer is cleared on each
-        import only the last import will be exported correctly."""
-        # clear the text buffer, or create new buffer
-        try:
-            namestxt = bpy.data.texts["FullNames"]
-            namestxt.clear()
-        except KeyError:
-            namestxt = bpy.data.texts.new("FullNames")
-            
-        # write the names to the text buffer
-        for block, shortname in self.nif_import.dict_names.items():
-            block_name = block.name.decode()
-            if block_name and shortname != block_name:
-                namestxt.write('%s;%s\n' % (shortname, block_name))
                 
                 

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -66,8 +66,8 @@ class Armature():
         """Scans an armature hierarchy, and returns a whole armature.
         This is done outside the normal node tree scan to allow for positioning
         of the bones before skins are attached."""
+        
         armature_name = self.nif_import.import_name(n_armature)
-
         b_armature_data = bpy.data.armatures.new(armature_name)
         b_armature_data.draw_type = 'STICK'
         b_armature_obj = create_b_obj(armature_name, b_armature_data)
@@ -117,7 +117,7 @@ class Armature():
         # (under the hood all bone space matrixes are multiplied together)
         n_bind = nif_utils.import_matrix(n_block, relative_to=n_armature)
         # get transformation in blender's coordinate space
-        b_bind = nif_utils.nif_bind_to_blender_bind(n_bind)
+        b_bind = armature.nif_bind_to_blender_bind(n_bind)
         # the following is a workaround because blender can no longer set matrices to bones directly
         tail, roll = nif_utils.mat3_to_vec_roll(b_bind.to_3x3())
         b_edit_bone.head = b_bind.to_translation()

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -79,30 +79,17 @@ class Armature():
             self.import_bone(n_child, b_armature_data, n_armature)
         self.fix_bone_lengths(b_armature_data)
         bpy.ops.object.mode_set(mode='OBJECT',toggle=False)
-        if NifOp.props.animation:
-            self.nif_import.animationhelper.create_action(b_armature_obj, armature_name+"-Anim")
 
         # The armature has been created in editmode,
         # now we are ready to set the bone keyframes.
-        # if NifOp.props.animation:
-            # self.nif_import.animationhelper.armature_animation.import_armature_animation(b_armature_obj)
-            
-        # constraints (priority)
-        # must be done outside edit mode hence after calling
-        for bone_name, b_posebone in b_armature_obj.pose.bones.items():
-            if bone_name in self.nif_import.dict_blocks:
-                n_block = self.nif_import.dict_blocks[bone_name]
-                self.nif_import.animationhelper.armature_animation.import_bone_animation(n_block, b_armature_obj, bone_name)
-                # find bone nif block
-                if bone_name.startswith("InvMarker"):
-                    bone_name = "InvMarker"
-                # store bone priority, if applicable
-                if n_block.name in self.nif_import.dict_bone_priorities:
-                    # TODO: Still use constraints to store priorities? Maybe use a property instead.
-                    constr = b_posebone.constraints.new('TRANSFORM')
-                    constr.name = "priority:%i" % self.nif_import.dict_bone_priorities[niBone.name]
-            else:
-                NifLog.info("'%s' can not be found in the NIF - unable to import additional data. This likely means your NIF structure duplicated bones".format(bone_name))
+        if NifOp.props.animation:
+            self.nif_import.animationhelper.create_action(b_armature_obj, armature_name+"-Anim")
+            for bone_name, b_posebone in b_armature_obj.pose.bones.items():
+                if bone_name in self.nif_import.dict_blocks:
+                    n_block = self.nif_import.dict_blocks[bone_name]
+                    self.nif_import.animationhelper.armature_animation.import_bone_animation(n_block, b_armature_obj, bone_name)
+                else:
+                    NifLog.info("'%s' can not be found in the NIF - unable to import animation. This likely means your NIF structure duplicated bones".format(bone_name))
         return b_armature_obj
         
     def import_bone(self, n_block, b_armature_data, n_armature, b_parent_bone=None):

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -90,16 +90,19 @@ class Armature():
         # constraints (priority)
         # must be done outside edit mode hence after calling
         for bone_name, b_posebone in b_armature_obj.pose.bones.items():
-            n_block = self.nif_import.dict_blocks[bone_name]
-            self.nif_import.animationhelper.armature_animation.import_bone_animation(n_block, b_armature_obj, bone_name)
-            # find bone nif block
-            if bone_name.startswith("InvMarker"):
-                bone_name = "InvMarker"
-            # store bone priority, if applicable
-            if n_block.name in self.nif_import.dict_bone_priorities:
-                # TODO: Still use constraints to store priorities? Maybe use a property instead.
-                constr = b_posebone.constraints.new('TRANSFORM')
-                constr.name = "priority:%i" % self.nif_import.dict_bone_priorities[niBone.name]
+            if bone_name in self.nif_import.dict_blocks:
+                n_block = self.nif_import.dict_blocks[bone_name]
+                self.nif_import.animationhelper.armature_animation.import_bone_animation(n_block, b_armature_obj, bone_name)
+                # find bone nif block
+                if bone_name.startswith("InvMarker"):
+                    bone_name = "InvMarker"
+                # store bone priority, if applicable
+                if n_block.name in self.nif_import.dict_bone_priorities:
+                    # TODO: Still use constraints to store priorities? Maybe use a property instead.
+                    constr = b_posebone.constraints.new('TRANSFORM')
+                    constr.name = "priority:%i" % self.nif_import.dict_bone_priorities[niBone.name]
+            else:
+                NifLog.info("'%s' can not be found in the NIF - unable to import additional data. This likely means your NIF structure duplicated bones".format(bone_name))
         return b_armature_obj
         
     def import_bone(self, n_block, b_armature_data, n_armature, b_parent_bone=None):

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -70,8 +70,8 @@ class Armature():
 
         b_armature_data = bpy.data.armatures.new(armature_name)
         b_armature_data.draw_type = 'STICK'
-        b_armature = create_b_obj(armature_name, b_armature_data)
-        b_armature.show_x_ray = True
+        b_armature_obj = create_b_obj(armature_name, b_armature_data)
+        b_armature_obj.show_x_ray = True
         
         # make armature editable and create bones
         bpy.ops.object.mode_set(mode='EDIT',toggle=False)
@@ -79,25 +79,28 @@ class Armature():
             self.import_bone(n_child, b_armature_data, n_armature)
         self.fix_bone_lengths(b_armature_data)
         bpy.ops.object.mode_set(mode='OBJECT',toggle=False)
+        if NifOp.props.animation:
+            self.nif_import.animationhelper.create_action(b_armature_obj, armature_name+"-Anim")
 
         # The armature has been created in editmode,
         # now we are ready to set the bone keyframes.
-        if NifOp.props.animation:
-            self.nif_import.animationhelper.armature_animation.import_armature_animation(b_armature)
+        # if NifOp.props.animation:
+            # self.nif_import.animationhelper.armature_animation.import_armature_animation(b_armature_obj)
             
         # constraints (priority)
         # must be done outside edit mode hence after calling
-        for bone_name, b_posebone in b_armature.pose.bones.items():
+        for bone_name, b_posebone in b_armature_obj.pose.bones.items():
+            n_block = self.nif_import.dict_blocks[bone_name]
+            self.nif_import.animationhelper.armature_animation.import_bone_animation(n_block, b_armature_obj, bone_name)
             # find bone nif block
             if bone_name.startswith("InvMarker"):
                 bone_name = "InvMarker"
-            niBone = self.nif_import.dict_blocks[bone_name]
             # store bone priority, if applicable
-            if niBone.name in self.nif_import.dict_bone_priorities:
+            if n_block.name in self.nif_import.dict_bone_priorities:
                 # TODO: Still use constraints to store priorities? Maybe use a property instead.
                 constr = b_posebone.constraints.new('TRANSFORM')
                 constr.name = "priority:%i" % self.nif_import.dict_bone_priorities[niBone.name]
-        return b_armature
+        return b_armature_obj
         
     def import_bone(self, n_block, b_armature_data, n_armature, b_parent_bone=None):
         """Adds a bone to the armature in edit mode."""

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -118,6 +118,78 @@ class Armature():
         for n_child in n_block.children:
             self.import_bone(n_child, b_armature_data, n_armature, b_edit_bone)
 
+    def import_skin(self, niBlock, b_obj, v_map):
+        """ Import a NiSkinInstance and its contents as vertex groups """
+        skininst = niBlock.skin_instance
+        if skininst:
+            skindata = skininst.data
+            bones = skininst.bones
+            # the usual case
+            if skindata.has_vertex_weights:
+                boneWeights = skindata.bone_list
+                for idx, n_bone in enumerate(bones):
+                    # skip empty bones (see pyffi issue #3114079)
+                    if not n_bone:
+                        continue
+                    vertex_weights = boneWeights[idx].vertex_weights
+                    # if we are in import geom only mode we have not stored the bones in the dict
+                    # groupname = self.dict_names[n_bone]
+                    groupname = self.nif_import.import_name(n_bone)
+                    if groupname not in b_obj.vertex_groups:
+                        v_group = b_obj.vertex_groups.new(groupname)
+                    for skinWeight in vertex_weights:
+                        vert = skinWeight.index
+                        weight = skinWeight.weight
+                        v_group.add([v_map[vert]], weight, 'REPLACE')
+            # WLP2 - hides the weights in the partition
+            else:
+                skinpartition = skininst.skin_partition
+                for block in skinpartition.skin_partition_blocks:
+                    # create all vgroups for this block's bones
+                    block_bone_names = [self.nif_import.import_name(bones[i]) for i in block.bones]
+                    for groupname in block_bone_names:
+                        b_obj.vertex_groups.new(groupname)
+
+                    # go over each vert in this block
+                    for vert, vertex_weights, bone_indices in zip(block.vertex_map,
+                                                                  block.vertex_weights,
+                                                                  block.bone_indices):
+                        # assign this vert's 4 weights to its 4 vgroups (at max)
+                        for w, b_i in zip(vertex_weights, bone_indices):
+                            if w > 0:
+                                groupname = block_bone_names[b_i]
+                                v_group = b_obj.vertex_groups[groupname]
+                                v_group.add([v_map[vert]], w, 'REPLACE')
+
+        # import body parts as vertex groups
+        if isinstance(skininst, NifFormat.BSDismemberSkinInstance):
+            skinpart_list = []
+            bodypart_flag = []
+            skinpart = niBlock.get_skin_partition()
+            for bodypart, skinpartblock in zip(
+                skininst.partitions, skinpart.skin_partition_blocks):
+                bodypart_wrap = NifFormat.BSDismemberBodyPartType()
+                bodypart_wrap.set_value(bodypart.body_part)
+                groupname = bodypart_wrap.get_detail_display()
+                # create vertex group if it did not exist yet
+                if groupname not in b_obj.vertex_groups:
+                    v_group = b_obj.vertex_groups.new(groupname)
+                    skinpart_index = len(skinpart_list)
+                    skinpart_list.append((skinpart_index, groupname))
+                    bodypart_flag.append(bodypart.part_flag)
+                # find vertex indices of this group
+                groupverts = [v_map[v_index]
+                              for v_index in skinpartblock.vertex_map]
+                # create the group
+                v_group.add(groupverts, 1, 'ADD')
+            b_obj.niftools_part_flags_panel.pf_partcount = len(skinpart_list)
+            for i, pl_name in skinpart_list:
+                b_obj_partflag = b_obj.niftools_part_flags.add()
+                # b_obj.niftools_part_flags.pf_partint = (i)
+                b_obj_partflag.name = (pl_name)
+                b_obj_partflag.pf_editorflag = (bodypart_flag[i].pf_editor_visible)
+                b_obj_partflag.pf_startflag = (bodypart_flag[i].pf_start_net_boneset)
+        
     def fix_bone_lengths(self, b_armature_data):
         """Sets all edit_bones to a suitable length."""
         for b_edit_bone in b_armature_data.edit_bones:

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -344,12 +344,11 @@ class Armature():
             self.complete_bone_tree(boneparent, skelroot)
 
     def is_bone(self, niBlock):
-        """Tests a NiNode to see if it's a bone."""
-        if not niBlock :
-            return False
-        for bones in self.dict_armatures.values():
-            if niBlock in bones:
-                return True
+        """Tests a NiNode to see if it has been marked as a bone."""
+        if niBlock:
+            for bones in self.dict_armatures.values():
+                if niBlock in bones:
+                    return True
 
     def is_armature_root(self, niBlock):
         """Tests a block to see if it's an armature."""

--- a/io_scene_nif/modules/collision/collision_export.py
+++ b/io_scene_nif/modules/collision/collision_export.py
@@ -45,7 +45,7 @@ from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.nif_logging import NifLog
 from io_scene_nif.utility.nif_global import NifOp
 
-class CollisionHelper():
+class Collision():
 
     FLOAT_MIN = -3.4028234663852886e+38
     FLOAT_MAX = +3.4028234663852886e+38
@@ -597,12 +597,6 @@ class CollisionHelper():
             raise nif_utils.NifError(
                 'cannot export collision type %s to collision shape list'
                 % b_obj.game.collision_bounds_type)
-
-
-class bound_export():
-
-    def __init__(self, parent):
-        self.nif_export = parent
 
     def export_bounding_box(self, b_obj, block_parent, bsbound=False):
         """Export a Morrowind or Oblivion bounding box."""

--- a/io_scene_nif/modules/collision/collision_export.py
+++ b/io_scene_nif/modules/collision/collision_export.py
@@ -272,8 +272,8 @@ class Collision():
             n_bhkrigidbody.unknown_7_shorts[5] = 44
             n_bhkrigidbody.unknown_7_shorts[6] = 0
 
-            # mass is 1.0 at the moment (unless property was set)
-            # will be fixed later
+            # mass is 1.0 at the moment (unless property was set on import or by the user)
+            # will be fixed in update_rigid_bodies()
             n_bhkrigidbody.mass = mass
             n_bhkrigidbody.linear_damping = linear_damping
             n_bhkrigidbody.angular_damping = angular_damping
@@ -286,7 +286,8 @@ class Collision():
             n_bhkrigidbody.penetration_depth = penetration_depth
             n_bhkrigidbody.motion_system = motion_system
             n_bhkrigidbody.deactivator_type = deactivator_type
-            n_bhkrigidbody.solver_deactivation = solver_deactivation 
+            n_bhkrigidbody.solver_deactivation = solver_deactivation
+            # todo [collision / properties / ui] expose unknowns to UI & make sure to keep defaults
             n_bhkrigidbody.unknown_byte_1 = 1
             n_bhkrigidbody.unknown_byte_2 = 1
             n_bhkrigidbody.quality_type = quality_type

--- a/io_scene_nif/modules/collision/collision_export.py
+++ b/io_scene_nif/modules/collision/collision_export.py
@@ -54,6 +54,12 @@ class Collision():
         self.nif_export = parent
         self.HAVOK_SCALE = parent.HAVOK_SCALE
 
+    def has_collision(self,):
+        """ Helper function that determines if a blend file contains a collider """
+        for b_obj in bpy.data.objects:
+            if b_obj.game.use_collision_bounds:
+                return b_obj
+
     def export_collision(self, b_obj, n_parent):
         """Main function for adding collision object b_obj to a node."""
         if NifOp.props.game == 'MORROWIND':
@@ -281,10 +287,10 @@ class Collision():
             n_bhkrigidbody.motion_system = motion_system
             n_bhkrigidbody.deactivator_type = deactivator_type
             n_bhkrigidbody.solver_deactivation = solver_deactivation 
-            n_bhkrigidbody.unknown_byte_1 = self.nif_export.EXPORT_OB_UNKNOWNBYTE1
-            n_bhkrigidbody.unknown_byte_2 = self.nif_export.EXPORT_OB_UNKNOWNBYTE2
+            n_bhkrigidbody.unknown_byte_1 = 1
+            n_bhkrigidbody.unknown_byte_2 = 1
             n_bhkrigidbody.quality_type = quality_type
-            n_bhkrigidbody.unknown_int_9 = self.nif_export.EXPORT_OB_WIND
+            n_bhkrigidbody.unknown_int_9 = 0
             
             # we will use n_col_body to attach shapes to below
             n_col_body = n_bhkrigidbody

--- a/io_scene_nif/modules/collision/collision_export.py
+++ b/io_scene_nif/modules/collision/collision_export.py
@@ -188,6 +188,9 @@ class CollisionHelper():
         deactivator_type = b_obj.nifcollision.deactivator_type
         solver_deactivation = b_obj.nifcollision.solver_deactivation
         quality_type = b_obj.nifcollision.quality_type
+        if not b_obj.rigid_body:
+            NifLog.warn("'{0}' has no rigid body, skipping rigid body export".format(b_obj.name))
+            return
         mass = b_obj.rigid_body.mass
         restitution = b_obj.rigid_body.restitution
         friction = b_obj.rigid_body.friction

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -602,7 +602,8 @@ class bound_import():
             #    *bbox.bounding_box.rotation.as_list())
             # ob.setLocation(
             #    *bbox.bounding_box.translation.as_list())
-        b_obj.niftools.bsxflags = NiObject.import_bsxflag_data(bbox)
+        # this was wrong, import_bsxflag_data should not be called on a 'BSBound' bbox but a root_block
+        # b_obj.niftools.bsxflags = NiObject.import_bsxflag_data(bbox)
         # TODO b_obj.niftools.objectflags = self.nif_import.objectflags
         b_obj.location = n_bbox_center
 

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -386,7 +386,7 @@ class bhkshape_import():
             b_obj.game.use_collision_bounds = True
             b_obj.game.collision_bounds_type = 'TRIANGLE_MESH'
             # radius: quick estimate
-            b_obj.game.radius = min(vert.co.length for vert in b_mesh.vertices)
+            b_obj.game.radius = min(vert.co.length for vert in b_obj.data.vertices)
             # set material
             b_obj.nifcollision.havok_material = NifFormat.HavokMaterial._enumkeys[subshape.material]
 

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -48,31 +48,6 @@ from pyffi.utils.quickhull import qhull3d
 from io_scene_nif.utility.nif_logging import NifLog
 from io_scene_nif.utility.nif_global import NifOp
 
-
-def box_from_extents(b_name, minx, maxx, miny, maxy, minz, maxz):
-    verts = []
-    for x in [minx, maxx]:
-        for y in [miny, maxy]:
-            for z in [minz, maxz]:
-                verts.append( (x,y,z) )
-    faces = [[0,1,3,2],[6,7,5,4],[0,2,6,4],[3,1,5,7],[4,5,1,0],[7,6,2,3]]
-    return mesh_from_data(b_name, verts, faces)
-    
-def create_ob(ob_name, ob_data):
-    ob = bpy.data.objects.new(ob_name, ob_data)
-    bpy.context.scene.objects.link(ob)
-    bpy.context.scene.objects.active = ob
-    return ob
-
-def mesh_from_data(name, verts, faces, wireframe = True):
-    me = bpy.data.meshes.new(name)
-    me.from_pydata(verts, [], faces)
-    me.update()
-    ob = create_ob(name, me)
-    if wireframe:
-        ob.draw_type = 'WIRE'
-    return ob
-
 class bhkshape_import():
     """Import basic and Havok Collision Shapes"""
 
@@ -245,7 +220,7 @@ class bhkshape_import():
         maxz = +bhkshape.dimensions.z * self.HAVOK_SCALE
 
         #create blender object
-        b_obj = box_from_extents("box", minx, maxx, miny, maxy, minz, maxz)
+        b_obj = self.nif_import.objecthelper.box_from_extents("box", minx, maxx, miny, maxy, minz, maxz)
 
         # set bounds type
         b_obj.draw_type = 'WIRE'
@@ -263,7 +238,7 @@ class bhkshape_import():
         # create sphere
         b_radius = bhkshape.radius * self.HAVOK_SCALE
         
-        b_obj = box_from_extents("sphere", -b_radius, b_radius, -b_radius, b_radius, -b_radius, b_radius)
+        b_obj = self.nif_import.objecthelper.box_from_extents("sphere", -b_radius, b_radius, -b_radius, b_radius, -b_radius, b_radius)
 
         # set bounds type
         b_obj.draw_type = 'WIRE'
@@ -287,7 +262,7 @@ class bhkshape_import():
         maxz = +(length + 2*b_radius) * (self.HAVOK_SCALE / 2)
 
         #create blender object
-        b_obj = box_from_extents("capsule", minx, maxx, miny, maxy, minz, maxz)
+        b_obj = self.nif_import.objecthelper.box_from_extents("capsule", minx, maxx, miny, maxy, minz, maxz)
 
         # set bounds type
         b_obj.draw_type = 'BOUNDS'
@@ -311,7 +286,7 @@ class bhkshape_import():
                                      self.HAVOK_SCALE * n_vert.z)
                                      for n_vert in bhkshape.vertices ])
 
-        b_obj = mesh_from_data("convexpoly", verts, faces)
+        b_obj = self.nif_import.objecthelper.mesh_from_data("convexpoly", verts, faces)
 
         b_obj.show_wire = True
         b_obj.draw_type = 'WIRE'
@@ -331,7 +306,7 @@ class bhkshape_import():
         # no factor 7 correction!!!
         verts = [ (v.x, v.y, v.z) for v in bhkshape.vertices ]
         faces = list(bhkshape.get_triangles())
-        b_obj = mesh_from_data("poly", verts, faces)
+        b_obj = self.nif_import.objecthelper.mesh_from_data("poly", verts, faces)
         
         # set bounds type
         b_obj.draw_type = 'WIRE'
@@ -374,11 +349,7 @@ class bhkshape_import():
                                   hktriangle.triangle.v_3 - vertex_offset) )
                 else:
                     continue
-            # todo: face normals are ignored here - are they even relevant?
-            # could just run the recalc normals operator if they are
-            # old solution was rather hacky anyway
-            
-            b_obj = mesh_from_data('poly%i' % subshape_num, verts, faces)
+            b_obj = self.nif_import.objecthelper.mesh_from_data('poly%i' % subshape_num, verts, faces)
 
             # set bounds type
             b_obj.draw_type = 'WIRE'
@@ -435,7 +406,7 @@ class bound_import():
                             % bbox.__class__.__name__)
 
         #create blender object
-        b_obj = box_from_extents(b_name, minx, maxx, miny, maxy, minz, maxz)
+        b_obj = self.nif_import.objecthelper.box_from_extents(b_name, minx, maxx, miny, maxy, minz, maxz)
         # link box to scene and set transform
         # XXX this is set in the import_branch() method
         # ob.matrix_local = mathutils.Matrix(

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -367,7 +367,6 @@ class bhkshape_import():
         b_obj.nifcollision.havok_material = NifFormat.HavokMaterial._enumkeys[bhkshape.material]
         for v, k in zip(NifFormat.SkyrimHavokMaterial._enumvalues, NifFormat.SkyrimHavokMaterial._enumkeys):
             if v == bhkshape.skyrim_material:
-                print("Found")
                 b_obj.nifcollision.skyrim_havok_material = k
                 break
         

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -45,7 +45,6 @@ import operator
 
 from pyffi.formats.nif import NifFormat
 from pyffi.utils.quickhull import qhull3d
-from io_scene_nif.modules.object.object_import import NiObject
 from io_scene_nif.utility.nif_logging import NifLog
 from io_scene_nif.utility.nif_global import NifOp
 

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -50,6 +50,30 @@ from io_scene_nif.utility.nif_logging import NifLog
 from io_scene_nif.utility.nif_global import NifOp
 
 
+def box_from_extents(b_name, minx, maxx, miny, maxy, minz, maxz):
+    verts = []
+    for x in [minx, maxx]:
+        for y in [miny, maxy]:
+            for z in [minz, maxz]:
+                verts.append( (x,y,z) )
+    faces = [[0,1,3,2],[6,7,5,4],[0,2,6,4],[3,1,5,7],[4,5,1,0],[7,6,2,3]]
+    return mesh_from_data(b_name, verts, faces)
+    
+def create_ob(ob_name, ob_data):
+    ob = bpy.data.objects.new(ob_name, ob_data)
+    bpy.context.scene.objects.link(ob)
+    bpy.context.scene.objects.active = ob
+    return ob
+
+def mesh_from_data(name, verts, faces, wireframe = True):
+    me = bpy.data.meshes.new(name)
+    me.from_pydata(verts, [], faces)
+    me.update()
+    ob = create_ob(name, me)
+    if wireframe:
+        ob.draw_type = 'WIRE'
+    return ob
+
 class bhkshape_import():
     """Import basic and Havok Collision Shapes"""
 
@@ -221,26 +245,8 @@ class bhkshape_import():
         minz = -bhkshape.dimensions.z * self.HAVOK_SCALE
         maxz = +bhkshape.dimensions.z * self.HAVOK_SCALE
 
-        b_mesh = bpy.data.meshes.new('box')
-        vert_list = {}
-        vert_index = 0
-
-        for x in [minx, maxx]:
-            for y in [miny, maxy]:
-                for z in [minz, maxz]:
-                    b_mesh.vertices.add(1)
-                    b_mesh.vertices[-1].co = (x,y,z)
-                    vert_list[vert_index] = [x,y,z]
-                    vert_index += 1
-
-        poly_gens = [[0,1,3,2],[6,7,5,4],[0,2,6,4],[3,1,5,7],[4,0,1,5],[7,6,2,3]]
-        b_mesh = poly_gen.col_poly_gen(b_mesh, poly_gens)
-
-        # link box to scene and set transform
-        b_obj = bpy.data.objects.new('box', b_mesh)
-        bpy.context.scene.objects.link(b_obj)
-        scn = bpy.context.scene
-        scn.objects.active = b_obj
+        #create blender object
+        b_obj = box_from_extents("box", minx, maxx, miny, maxy, minz, maxz)
 
         # set bounds type
         b_obj.draw_type = 'WIRE'
@@ -250,11 +256,6 @@ class bhkshape_import():
         b_obj.game.radius = bhkshape.radius
         b_obj.nifcollision.havok_material = NifFormat.HavokMaterial._enumkeys[bhkshape.material]
         
-        # Recalculate mesh to render correctly
-        b_mesh.validate()
-        b_mesh.update()
-        b_obj.select = True
-
         return [ b_obj ]
 
 
@@ -262,33 +263,8 @@ class bhkshape_import():
         """Import a BhkSphere block as a simple uv-sphere collision object"""
         # create sphere
         b_radius = bhkshape.radius * self.HAVOK_SCALE
-                
-        minx = -b_radius
-        maxx = +b_radius
-        miny = -b_radius
-        maxy = +b_radius
-        minz = -b_radius
-        maxz = +b_radius
-
-        b_mesh = bpy.data.meshes.new('sphere')
-        vert_list = {}
-        vert_index = 0
-
-        for x in [minx, maxx]:
-            for y in [miny, maxy]:
-                for z in [minz, maxz]:
-                    b_mesh.vertices.add(1)
-                    b_mesh.vertices[-1].co = (x,y,z)
-                    vert_list[vert_index] = [x,y,z]
-                    vert_index += 1
-
-        poly_gens = [[0,1,3,2],[6,7,5,4],[0,2,6,4],[3,1,5,7],[4,0,1,5],[7,6,2,3]]
-        b_mesh = poly_gen.col_poly_gen(b_mesh, poly_gens)
-
-        b_obj = bpy.data.objects.new('sphere', b_mesh)
-        bpy.context.scene.objects.link(b_obj)
-        scn = bpy.context.scene
-        scn.objects.active = b_obj
+        
+        b_obj = box_from_extents("sphere", -b_radius, b_radius, -b_radius, b_radius, -b_radius, b_radius)
 
         # set bounds type
         b_obj.draw_type = 'WIRE'
@@ -297,12 +273,6 @@ class bhkshape_import():
         b_obj.game.collision_bounds_type = 'SPHERE'
         b_obj.game.radius = bhkshape.radius
         b_obj.nifcollision.havok_material = NifFormat.HavokMaterial._enumkeys[bhkshape.material]
-
-        # Recalculate mesh to render correctly
-        b_mesh = b_obj.data
-        b_mesh.validate()
-        b_mesh.update()
-        b_obj.select = True
 
         return [ b_obj ]
 
@@ -317,30 +287,8 @@ class bhkshape_import():
         minz = -(length + 2*b_radius) * (self.HAVOK_SCALE / 2)
         maxz = +(length + 2*b_radius) * (self.HAVOK_SCALE / 2)
 
-        b_mesh = bpy.data.meshes.new('capsule')
-        vert_list = {}
-        vert_index = 0
-
-        for x in [minx, maxx]:
-            for y in [miny, maxy]:
-                for z in [minz, maxz]:
-                    b_mesh.vertices.add(1)
-                    b_mesh.vertices[-1].co = (x,y,z)
-                    vert_list[vert_index] = [x,y,z]
-                    vert_index += 1
-
-        poly_gens = [[0,1,3,2],[6,7,5,4],[0,2,6,4],[3,1,5,7],[4,5,1,0],[7,6,2,3]]
-        b_mesh = poly_gen.col_poly_gen(b_mesh, poly_gens)
-
-        # Recalculate mesh to render correctly
-        b_mesh.validate()
-        b_mesh.update()
-
-        # link box to scene and set transform
-        b_obj = bpy.data.objects.new('Capsule', b_mesh)
-        bpy.context.scene.objects.link(b_obj)
-        scn = bpy.context.scene
-        scn.objects.active = b_obj
+        #create blender object
+        b_obj = box_from_extents("capsule", minx, maxx, miny, maxy, minz, maxz)
 
         # set bounds type
         b_obj.draw_type = 'BOUNDS'
@@ -358,28 +306,21 @@ class bhkshape_import():
             NifLog.warn("BhkCapsuleShape with identical points: using arbitrary axis")
             normal = mathutils.Vector((0, 0, 1))
             
-        minindex = min((abs(x), i) for i, x in enumerate(normal))[1]
-        orthvec = mathutils.Vector([(1 if i == minindex else 0) for i in (0,1,2)])
+        # minindex = min((abs(x), i) for i, x in enumerate(normal))[1]
+        # orthvec = mathutils.Vector([(1 if i == minindex else 0) for i in (0,1,2)])
         
-        vec1 = mathutils.Vector.cross(normal, orthvec)
-        vec1.normalize()
-        vec2 = mathutils.Vector.cross(normal, vec1)
+        # vec1 = mathutils.Vector.cross(normal, orthvec)
+        # vec1.normalize()
+        # vec2 = mathutils.Vector.cross(normal, vec1)
         
-        # the rotation matrix should be such that (0,0,1) maps to normal
-        transform = mathutils.Matrix([vec1, vec2, normal]).transposed()
-        transform.resize_4x4()
-        transform[0][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.x + bhkshape.second_point.x)
-        transform[1][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.y + bhkshape.second_point.y)
-        transform[2][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.z + bhkshape.second_point.z)
-        b_obj.matrix_local = transform
+        # # the rotation matrix should be such that (0,0,1) maps to normal
+        # transform = mathutils.Matrix([vec1, vec2, normal]).transposed()
+        # transform.resize_4x4()
+        # transform[0][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.x + bhkshape.second_point.x)
+        # transform[1][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.y + bhkshape.second_point.y)
+        # transform[2][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.z + bhkshape.second_point.z)
+        # b_obj.matrix_local = transform
 
-        # Recalculate mesh to render correctly
-        b_mesh = b_obj.data
-        b_mesh.validate()
-        b_mesh.update()
-        b_obj.select = True
-
-        # return object
         return [ b_obj ]
 
 
@@ -387,27 +328,12 @@ class bhkshape_import():
         """Import a BhkConvexVertex block as a convex hull collision object"""
 
         # find vertices (and fix scale)
-        n_vertices, n_triangles = qhull3d(
-                                  [ (self.HAVOK_SCALE * n_vert.x,
+        verts, faces = qhull3d(   [ (self.HAVOK_SCALE * n_vert.x,
                                      self.HAVOK_SCALE * n_vert.y,
                                      self.HAVOK_SCALE * n_vert.z)
                                      for n_vert in bhkshape.vertices ])
 
-        # create convex mesh
-        b_mesh = bpy.data.meshes.new('convexpoly')
-
-        for n_vert in n_vertices:
-            b_mesh.vertices.add(1)
-            b_mesh.vertices[-1].co = n_vert
-
-        poly_gens = n_triangles
-        b_mesh = poly_gen.col_poly_gen(b_mesh, poly_gens)
-
-        # link mesh to scene and set transform
-        b_obj = bpy.data.objects.new('Convexpoly', b_mesh)
-        bpy.context.scene.objects.link(b_obj)
-        scn = bpy.context.scene
-        scn.objects.active = b_obj
+        b_obj = mesh_from_data("convexpoly", verts, faces)
 
         b_obj.show_wire = True
         b_obj.draw_type = 'WIRE'
@@ -419,32 +345,16 @@ class bhkshape_import():
         b_obj.game.radius = bhkshape.radius
         b_obj.nifcollision.havok_material = NifFormat.HavokMaterial._enumkeys[bhkshape.material]
 
-        # Recalculate mesh to render correctly
-        b_mesh = b_obj.data
-        b_mesh.validate()
-        b_mesh.update()
-        b_obj.select = True
-
         return [ b_obj ]
 
 
     def import_nitristrips(self, bhkshape):
         """Import a NiTriStrips block as a Triangle-Mesh collision object"""
-
-        b_mesh = bpy.data.meshes.new('poly')
         # no factor 7 correction!!!
-        for n_vert in bhkshape.vertices:
-            b_mesh.vertices.add(1)
-            b_mesh.vertices[-1].co = (n_vert.x, n_vert.y, n_vert.z)
-
-        poly_gens = [[x,y,z,] for x,y,z in list(bhkshape.get_triangles())]
-        b_mesh = poly_gen.col_poly_gen(b_mesh, poly_gens)
-
-        # link mesh to scene and set transform
-        b_obj = bpy.data.objects.new('poly', b_mesh)
-        bpy.context.scene.objects.link(b_obj)
-        scn = bpy.context.scene
-        scn.objects.active = b_obj
+        verts = [ (v.x, v.y, v.z) for v in bhkshape.vertices ]
+        faces = list(bhkshape.get_triangles())
+        b_obj = mesh_from_data("poly", verts, faces)
+        
         # set bounds type
         b_obj.draw_type = 'WIRE'
         b_obj.draw_bounds_type = 'BOX'
@@ -453,12 +363,6 @@ class bhkshape_import():
         # radius: quick estimate
         b_obj.game.radius = bhkshape.radius
         b_obj.nifcollision.havok_material = NifFormat.HavokMaterial._enumkeys[self.havok_mat]
-
-        # Recalculate mesh to render correctly
-        b_mesh = b_obj.data
-        b_mesh.validate()
-        b_mesh.update()
-        b_obj.select = True
 
         return [ b_obj ]
 
@@ -475,46 +379,28 @@ class bhkshape_import():
             subshapes = bhkshape.data.sub_shapes
 
         for subshape_num, subshape in enumerate(subshapes):
-            b_mesh = bpy.data.meshes.new('poly:%i' % subshape_num)
-
+            verts = []
+            faces = []
             for vert_index in range(vertex_offset, vertex_offset + subshape.num_vertices):
-                b_vert = bhkshape.data.vertices[vert_index]
-                b_mesh.vertices.add(1)
-                b_mesh.vertices[-1].co = (b_vert.x * self.HAVOK_SCALE,
-                                          b_vert.y * self.HAVOK_SCALE,
-                                          b_vert.z * self.HAVOK_SCALE)
+                n_vert = bhkshape.data.vertices[vert_index]
+                verts.append( (n_vert.x * self.HAVOK_SCALE,
+                               n_vert.y * self.HAVOK_SCALE,
+                               n_vert.z * self.HAVOK_SCALE) )
 
             for hktriangle in bhkshape.data.triangles:
                 if ((vertex_offset <= hktriangle.triangle.v_1)
                     and (hktriangle.triangle.v_1
                          < vertex_offset + subshape.num_vertices)):
-                    b_mesh.polygons.add(1)
-                    b_mesh.polygons[-1].vertices = [
-                                             hktriangle.triangle.v_1 - vertex_offset,
-                                             hktriangle.triangle.v_2 - vertex_offset,
-                                             hktriangle.triangle.v_3 - vertex_offset]
+                    faces.append((hktriangle.triangle.v_1 - vertex_offset,
+                                  hktriangle.triangle.v_2 - vertex_offset,
+                                  hktriangle.triangle.v_3 - vertex_offset) )
                 else:
                     continue
-                # check face normal
-                align_plus = sum(abs(x)
-                                 for x in ( b_mesh.polygons[-1].normal[0] + hktriangle.normal.x,
-                                            b_mesh.polygons[-1].normal[1] + hktriangle.normal.y,
-                                            b_mesh.polygons[-1].normal[2] + hktriangle.normal.z ))
-                align_minus = sum(abs(x)
-                                  for x in ( b_mesh.polygons[-1].normal[0] - hktriangle.normal.x,
-                                             b_mesh.polygons[-1].normal[1] - hktriangle.normal.y,
-                                             b_mesh.polygons[-1].normal[2] - hktriangle.normal.z ))
-                # fix face orientation
-                if align_plus < align_minus:
-                    b_mesh.polygons[-1].vertices = ( b_mesh.polygons[-1].vertices[1],
-                                                  b_mesh.polygons[-1].vertices[0],
-                                                  b_mesh.polygons[-1].vertices[2] )
-
-            # link mesh to scene and set transform
-            b_obj = bpy.data.objects.new('poly%i' % subshape_num, b_mesh)
-            bpy.context.scene.objects.link(b_obj)
-            scn = bpy.context.scene
-            scn.objects.active = b_obj
+            # todo: face normals are ignored here - are they even relevant?
+            # could just run the recalc normals operator if they are
+            # old solution was rather hacky anyway
+            
+            b_obj = mesh_from_data('poly%i' % subshape_num, verts, faces)
 
             # set bounds type
             b_obj.draw_type = 'WIRE'
@@ -525,12 +411,6 @@ class bhkshape_import():
             b_obj.game.radius = min(vert.co.length for vert in b_mesh.vertices)
             # set material
             b_obj.nifcollision.havok_material = NifFormat.HavokMaterial._enumkeys[subshape.material]
-
-            # Recalculate mesh to render correctly
-            b_mesh = b_obj.data
-            b_mesh.validate()
-            b_mesh.update()
-            b_obj.select = True
 
             vertex_offset += subshape.num_vertices
             hk_objects.append(b_obj)
@@ -548,7 +428,7 @@ class bound_import():
 
         # calculate bounds
         if isinstance(bbox, NifFormat.BSBound):
-            b_mesh = bpy.data.meshes.new('BSBound')
+            b_name = 'BSBound'
             minx = bbox.center.x - bbox.dimensions.x
             miny = bbox.center.y - bbox.dimensions.y
             minz = bbox.center.z - bbox.dimensions.z
@@ -560,7 +440,7 @@ class bound_import():
         elif isinstance(bbox, NifFormat.NiNode):
             if not bbox.has_bounding_box:
                 raise ValueError("Expected NiNode with bounding box.")
-            b_mesh = bpy.data.meshes.new('Bounding Box')
+            b_name = 'Bounding Box'
 
             # Ninode's(bbox) behaves like a seperate mesh.
             # bounding_box center(bbox.bounding_box.translation) is relative to the bound_box
@@ -576,34 +456,15 @@ class bound_import():
             raise TypeError("Expected BSBound or NiNode but got %s."
                             % bbox.__class__.__name__)
 
-        # create mesh
-        for x in [minx, maxx]:
-            for y in [miny, maxy]:
-                for z in [minz, maxz]:
-                    b_mesh.vertices.add(1)
-                    b_mesh.vertices[-1].co = (x,y,z)
-
-        poly_gens = [[0,1,3,2],[6,7,5,4],[0,2,6,4],[3,1,5,7],[4,5,1,0],[7,6,2,3]]
-        b_mesh = poly_gen.col_poly_gen(b_mesh, poly_gens)
-
+        #create blender object
+        b_obj = box_from_extents(b_name, minx, maxx, miny, maxy, minz, maxz)
         # link box to scene and set transform
-        if isinstance(bbox, NifFormat.BSBound):
-            b_obj = bpy.data.objects.new('BSBound', b_mesh)
-            bpy.context.scene.objects.link(b_obj)
-            scn = bpy.context.scene
-            scn.objects.active = b_obj
-        else:
-            b_obj = bpy.data.objects.new('Bounding Box', b_mesh)
-            bpy.context.scene.objects.link(b_obj)
-            scn = bpy.context.scene
-            scn.objects.active = b_obj
-            # XXX this is set in the import_branch() method
-            # ob.matrix_local = mathutils.Matrix(
-            #    *bbox.bounding_box.rotation.as_list())
-            # ob.setLocation(
-            #    *bbox.bounding_box.translation.as_list())
-        # this was wrong, import_bsxflag_data should not be called on a 'BSBound' bbox but a root_block
-        # b_obj.niftools.bsxflags = NiObject.import_bsxflag_data(bbox)
+        # XXX this is set in the import_branch() method
+        # ob.matrix_local = mathutils.Matrix(
+        #    *bbox.bounding_box.rotation.as_list())
+        # ob.setLocation(
+        #    *bbox.bounding_box.translation.as_list())
+        
         # TODO b_obj.niftools.objectflags = self.nif_import.objectflags
         b_obj.location = n_bbox_center
 
@@ -616,59 +477,4 @@ class bound_import():
         # quick radius estimate
         b_obj.game.radius = max(maxx, maxy, maxz)
         
-        b_mesh = b_obj.data
-        b_mesh.validate()
-        b_mesh.update()
-        b_obj.select = True
-        
         return b_obj
-
-
-class poly_gen():
-    
-    def __init__(self, parent):
-        self.nif_import = parent
-
-    def col_poly_gen(self, poly_gens):
-        f_map = [None]*len(poly_gens)
-        b_f_index = len(self.polygons)
-        bf2_index = len(self.polygons)
-        bl_index = len(self.loops)
-        poly_count = len(poly_gens)
-        self.polygons.add(poly_count)
-        llp_count_list = list()
-        for l_count in poly_gens:
-            for lp_count in l_count:
-                llp_count_list.append(lp_count)
-        self.loops.add(len(llp_count_list))
-        num_new_faces = 0 # counter for debugging
-        unique_faces = list() # to avoid duplicate polygons
-        tri_point_list = list()
-        for i, f in enumerate(poly_gens):
-            # get face index
-            f_verts = [vert_index for vert_index in f]
-            if tuple(f_verts) in unique_faces:
-                continue
-            unique_faces.append(tuple(f_verts))
-            f_map[i] = b_f_index
-            tri_point_list.append(len(poly_gens[i]))
-            ls_list = list()
-            b_f_index += 1
-            num_new_faces += 1
-        for ls1 in range(0, num_new_faces * (tri_point_list[len(ls_list)]), (tri_point_list[len(ls_list)])):
-            ls_list.append((ls1 + bl_index))
-        for i in range(len(unique_faces)):
-            if f_map[i] is None:
-                continue
-            self.polygons[f_map[i]].loop_start = ls_list[(f_map[i] - bf2_index)]
-            self.polygons[f_map[i]].loop_total = len(unique_faces[(f_map[i] - bf2_index)])
-            l = 0
-            lp_points = [loop_point for loop_point in poly_gens[(f_map[i] - bf2_index)]]
-            while l < (len(poly_gens[(f_map[i] - bf2_index)])):
-                self.loops[(l + (bl_index))].vertex_index = lp_points[l]
-                l += 1
-            bl_index += (len(poly_gens[(f_map[i] - bf2_index)]))            
-        return self
-    
-    
-    

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -55,9 +55,6 @@ class Collision():
         self.nif_import = parent
         self.HAVOK_SCALE = parent.HAVOK_SCALE
 
-    def get_havok_objects(self):
-        return self.nif_import.dict_havok_objects
-
     def import_collision(self, n_node):
         """ Imports a NiNode's collision_object, if present"""
         if n_node.collision_object:

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -297,30 +297,9 @@ class bhkshape_import():
         b_obj.game.collision_bounds_type = 'CAPSULE'
         b_obj.game.radius = bhkshape.radius*self.HAVOK_SCALE
         b_obj.nifcollision.havok_material = NifFormat.HavokMaterial._enumkeys[bhkshape.material]
-
-        # find transform
-        if length > NifOp.props.epsilon:
-            normal = (bhkshape.first_point - bhkshape.second_point) / length
-            normal = mathutils.Vector((normal.x, normal.y, normal.z))
-        else:
-            NifLog.warn("BhkCapsuleShape with identical points: using arbitrary axis")
-            normal = mathutils.Vector((0, 0, 1))
-            
-        # minindex = min((abs(x), i) for i, x in enumerate(normal))[1]
-        # orthvec = mathutils.Vector([(1 if i == minindex else 0) for i in (0,1,2)])
         
-        # vec1 = mathutils.Vector.cross(normal, orthvec)
-        # vec1.normalize()
-        # vec2 = mathutils.Vector.cross(normal, vec1)
-        
-        # # the rotation matrix should be such that (0,0,1) maps to normal
-        # transform = mathutils.Matrix([vec1, vec2, normal]).transposed()
-        # transform.resize_4x4()
-        # transform[0][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.x + bhkshape.second_point.x)
-        # transform[1][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.y + bhkshape.second_point.y)
-        # transform[2][3] = (self.HAVOK_SCALE / 2) * (bhkshape.first_point.z + bhkshape.second_point.z)
-        # b_obj.matrix_local = transform
-
+        # center around middle; will acount for bone length once it is parented
+        b_obj.location.y = length / 2 * self.HAVOK_SCALE
         return [ b_obj ]
 
 

--- a/io_scene_nif/modules/constraint/constraint_export.py
+++ b/io_scene_nif/modules/constraint/constraint_export.py
@@ -185,7 +185,7 @@ class constraint_export():
                     b_constr.pivot_x,
                     b_constr.pivot_y,
                     b_constr.pivot_z,
-                    ])
+                    ]) / self.HAVOK_SCALE
                 constr_matrix = mathutils.Euler((
                     b_constr.axis_x,
                     b_constr.axis_y,
@@ -216,13 +216,13 @@ class constraint_export():
                 # (this is O * T * B' * B^{-1} at once)
                 transform = mathutils.Matrix(
                     b_obj.matrix_local)
-                pivot = pivot * transform
+                # pivot = pivot * transform
                 constr_matrix = constr_matrix * transform.to_3x3()
 
                 # export hkdescriptor pivot point
-                hkdescriptor.pivot_a.x = pivot[0] / self.HAVOK_SCALE
-                hkdescriptor.pivot_a.y = pivot[1] / self.HAVOK_SCALE
-                hkdescriptor.pivot_a.z = pivot[2] / self.HAVOK_SCALE
+                # hkdescriptor.pivot_a.x = pivot[0]
+                # hkdescriptor.pivot_a.y = pivot[1]
+                # hkdescriptor.pivot_a.z = pivot[2]
                 # export hkdescriptor axes and other parameters
                 # (also see import_nif.py NifImport.import_bhk_constraints)
                 axis_x = mathutils.Vector([1,0,0]) * constr_matrix
@@ -280,4 +280,7 @@ class constraint_export():
 
                 # do AB
                 hkconstraint.update_a_b(root_block)
+                hkdescriptor.pivot_b.x = pivot[0]
+                hkdescriptor.pivot_b.y = pivot[1]
+                hkdescriptor.pivot_b.z = pivot[2]
 

--- a/io_scene_nif/modules/constraint/constraint_export.py
+++ b/io_scene_nif/modules/constraint/constraint_export.py
@@ -75,7 +75,7 @@ class constraint_export():
                     NifLog.warn("Only Oblivion/Fallout/Skyrim rigid body constraints currently supported: Skipping {0}.".format(b_constr))
                     continue
                 # check that the object is a rigid body
-                for otherbody, otherobj in self.nif_export.dict_blocks.items():
+                for otherbody, otherobj in self.nif_export.block_to_obj.items():
                     if isinstance(otherbody, NifFormat.bhkRigidBody) \
                         and otherobj is b_obj:
                         hkbody = otherbody
@@ -159,7 +159,7 @@ class constraint_export():
                     NifLog.warn("Constraint {0} has no target, skipped".format(b_constr))
                     continue
                 # find target's bhkRigidBody
-                for otherbody, otherobj in self.nif_export.dict_blocks.items():
+                for otherbody, otherobj in self.nif_export.block_to_obj.items():
                     if isinstance(otherbody, NifFormat.bhkRigidBody) \
                         and otherobj == targetobj:
                         hkconstraint.entities[1] = otherbody

--- a/io_scene_nif/modules/constraint/constraint_import.py
+++ b/io_scene_nif/modules/constraint/constraint_import.py
@@ -157,9 +157,9 @@ class constraint_import():
 
             # get pivot point
             pivot = mathutils.Vector((
-                hkdescriptor.pivot_a.x * self.HAVOK_SCALE,
-                hkdescriptor.pivot_a.y * self.HAVOK_SCALE,
-                hkdescriptor.pivot_a.z * self.HAVOK_SCALE))
+                hkdescriptor.pivot_b.x,
+                hkdescriptor.pivot_b.y,
+                hkdescriptor.pivot_b.z)) * self.HAVOK_SCALE
 
             # get z- and x-axes of the constraint
             # (also see export_nif.py NifImport.export_constraints)
@@ -297,7 +297,7 @@ class constraint_import():
                 transform[1][3] = hkbody.translation.y * self.HAVOK_SCALE
                 transform[2][3] = hkbody.translation.z * self.HAVOK_SCALE
                 # apply transform
-                pivot = pivot * transform
+                # pivot = pivot * transform
                 transform = transform.to_3x3()
                 axis_z = axis_z * transform
                 axis_x = axis_x * transform
@@ -318,16 +318,16 @@ class constraint_import():
                     # axis_x = axis_x * transform
                     # break
 
-            # cancel out bone tail translation
-            if b_hkobj.parent_bone:
-                pivot[1] -= b_hkobj.parent.data.bones[
-                    b_hkobj.parent_bone].length
+            # # cancel out bone tail translation
+            # if b_hkobj.parent_bone:
+            #     pivot[1] -= b_hkobj.parent.data.bones[
+            #         b_hkobj.parent_bone].length
 
             # cancel out object transform
             transform = mathutils.Matrix(
                 b_hkobj.matrix_local)
             transform.invert()
-            pivot = pivot * transform
+            # pivot = pivot * transform
             transform = transform.to_3x3()
             axis_z = axis_z * transform
             axis_x = axis_x * transform

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -295,8 +295,8 @@ class ObjectHelper:
         # exporting an object, so first create node of correct type
         # TODO: rework to get node type from nif format based on custom value?
         try:
-            n_node_type = b_obj.getProperty("Type").data
-        except (RuntimeError, AttributeError, NameError):
+            n_node_type = b_obj["type"]
+        except:
             n_node_type = "NiNode"
 
         n_node = self.create_block(n_node_type, b_obj)
@@ -363,8 +363,8 @@ class ObjectHelper:
         n_node.lod_levels.update_size()
         n_range_data.lod_levels.update_size()
         for b_child, n_lod_level, n_rd_lod_level in zip(b_children, n_node.lod_levels, n_range_data.lod_levels):
-            n_lod_level.near_extent = b_child.getProperty("Near Extent").data
-            n_lod_level.far_extent = b_child.getProperty("Far Extent").data
+            n_lod_level.near_extent = b_child["near_extent"]
+            n_lod_level.far_extent = b_child["far_extent"]
             n_rd_lod_level.near_extent = n_lod_level.near_extent
             n_rd_lod_level.far_extent = n_lod_level.far_extent
 

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -405,14 +405,14 @@ class ObjectHelper:
 
             # if there is a bone parent then the object is parented then get the matrix relative to the bone parent head
             if b_obj.parent_bone:
-            
-                # first multiply with inverse of the Blender bone matrix
+                # get parent bone
                 parent_bone = b_obj.parent.data.bones[b_obj.parent_bone]
+                # restore bone length that was substracted here on import
+                matrix.translation.y += parent_bone.length
                 
-                #undo the calculations from import
-                matrix =  parent_bone.matrix_local.to_3x3().to_4x4() * matrix
-                #but here we add to the X loc instead of Y due to the coordinate changes
-                matrix.translation.x += parent_bone.length
+                # undo the calculations from import - multiply with inverse of the Blender bone matrix
+                matrix = parent_bone.matrix_local.to_3x3().to_4x4() * matrix
+                
         #Nonetype, maybe other weird stuff
         else:
             matrix = mathutils.Matrix()

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -165,12 +165,12 @@ class ObjectHelper:
             self.nif_export.collisionhelper.export_collision(b_obj, parent_block)
             return None  # done; stop here
 
-        elif b_obj_type == 'MESH' and b_obj.show_bounds and b_obj.name.lower().startswith('bsbound'):
+        elif b_obj_type == 'MESH' and b_obj.name.lower().startswith('bsbound'):
             # add a bounding box
             self.nif_export.boundhelper.export_bounding_box(b_obj, parent_block, bsbound=True)
             return None  # done; stop here
 
-        elif b_obj_type == 'MESH' and b_obj.show_bounds and b_obj.name.lower().startswith("bounding box"):
+        elif b_obj_type == 'MESH' and b_obj.name.lower().startswith("bounding box"):
             # Morrowind bounding box
             self.nif_export.boundhelper.export_bounding_box(b_obj, parent_block, bsbound=False)
             return None  # done; stop here

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -336,12 +336,14 @@ class ObjectHelper:
         """Returns the original imported name if present, or the name by which
         the object was exported already.
         """
-        try:
-            longname = b_obj.niftools.longname
-        except:
-            longname = ""
-        if not longname:
-            longname = self.get_unique_name(b_obj.name)
+        longname = ""
+        if b_obj:
+            try:
+                longname = b_obj.niftools.longname
+            except:
+                pass
+            if not longname:
+                longname = self.get_unique_name(b_obj.name)
         return longname
 
     def export_range_lod_data(self, n_node, b_obj):

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -262,15 +262,6 @@ class ObjectHelper:
 
         return node
 
-    # Export a blender object ob of the type mesh, child of nif block
-    # parent_block, as NiTriShape and NiTriShapeData blocks, possibly
-    # along with some NiTexturingProperty, NiSourceTexture,
-    # NiMaterialProperty, and NiAlphaProperty blocks. We export one
-    # trishape block per mesh material. We also export vertex weights.
-    #
-    # The parameter trishape_name passes on the name for meshes that
-    # should be exported as a single mesh.
-
     def create_ninode(self, b_obj=None):
         """Essentially a wrapper around create_block() that creates nodes of the right type"""
         # when no b_obj is passed, it means we create a root node
@@ -417,7 +408,18 @@ class MeshHelper:
     def __init__(self, parent):
         self.nif_export = parent
 
+
     def export_tri_shapes(self, b_obj, parent_block, trishape_name=None):
+        """ 
+        Export a blender object ob of the type mesh, child of nif block
+        parent_block, as NiTriShape and NiTriShapeData blocks, possibly
+        along with some NiTexturingProperty, NiSourceTexture,
+        NiMaterialProperty, and NiAlphaProperty blocks. We export one
+        trishape block per mesh material. We also export vertex weights.
+        
+        The parameter trishape_name passes on the name for meshes that
+        should be exported as a single mesh.
+        """
         NifLog.info("Exporting {0}".format(b_obj))
 
         assert (b_obj.type == 'MESH')

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -1381,7 +1381,9 @@ class MeshHelper:
                         # fix data consistency type
                         tridata.consistency_flags = b_obj.niftools.consistency_flags
         return trishape
+    
     def smooth_mesh_seams(self, b_objs):
+        """ Finds vertices that are shared between all blender objects and averages their normals"""
         # get shared vertices
         NifLog.info("Smoothing seams between objects...")
         vdict = {}

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -209,12 +209,12 @@ class ObjectHelper:
             return None
         if b_obj_type == 'MESH' and b_obj.name.lower().startswith('bsbound'):
             # add a bounding box
-            self.nif_export.boundhelper.export_bounding_box(b_obj, n_parent, bsbound=True)
+            self.nif_export.collisionhelper.export_bounding_box(b_obj, n_parent, bsbound=True)
             return None  # done; stop here
 
         elif b_obj_type == 'MESH' and b_obj.name.lower().startswith("bounding box"):
             # Morrowind bounding box
-            self.nif_export.boundhelper.export_bounding_box(b_obj, n_parent, bsbound=False)
+            self.nif_export.collisionhelper.export_bounding_box(b_obj, n_parent, bsbound=False)
             return None  # done; stop here
 
         elif b_obj_type == 'MESH':

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -162,7 +162,7 @@ class ObjectHelper:
         has_anim = True if b_obj_anim_data and b_obj_anim_data.action.fcurves else False
         if node_name == 'RootCollisionNode':
             # -> root collision node (can be mesh or empty)
-            self.nif_export.export_collision(b_obj, parent_block)
+            self.nif_export.collisionhelper.export_collision(b_obj, parent_block)
             return None  # done; stop here
 
         elif b_obj_type == 'MESH' and b_obj.show_bounds and b_obj.name.lower().startswith('bsbound'):
@@ -188,7 +188,7 @@ class ObjectHelper:
             has_track = self.has_track(b_obj)
 
             if is_collision:
-                self.nif_export.export_collision(b_obj, parent_block)
+                self.nif_export.collisionhelper.export_collision(b_obj, parent_block)
                 return None  # done; stop here
             elif has_anim or has_children or is_multimaterial or has_track:
                 # create a ninode as parent of this mesh for the hierarchy to work out

--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -410,7 +410,7 @@ class ObjectHelper:
         """
 
         if isinstance(b_obj, bpy.types.Bone):
-            matrix = nif_utils.get_bind_matrix(b_obj)
+            matrix = armature.get_bind_matrix(b_obj)
 
         elif isinstance(b_obj, bpy.types.Object):
             # TODO MOVE TO ARMATUREHELPER

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -121,7 +121,7 @@ class Object:
         # map blender short name to nif block
         self.nif_import.dict_blocks[b_obj.name] = n_block
         
-    def import_range_lod_data(self, n_node, b_obj):
+    def import_range_lod_data(self, n_node, b_obj, b_children):
         """ Import LOD ranges and mark b_obj as a LOD node """
         if isinstance(n_node, NifFormat.NiLODNode):
             b_obj["type"] = "NiLODNode"
@@ -130,7 +130,8 @@ class Object:
             # need more examples - just a guess here
             if not range_data.lod_levels:
                 range_data = n_node.lod_level_data
-            for lod_level, b_child in zip(range_data.lod_levels, b_obj.children):
+            # can't just take b_obj.children because the order doesn't match
+            for lod_level, b_child in zip(range_data.lod_levels, b_children):
                 b_child["near_extent"] = lod_level.near_extent
                 b_child["far_extent"] = lod_level.far_extent
 

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -50,11 +50,10 @@ class Object:
         # self.dict_names = {}
         # self.dict_blocks = {}
     
-    @staticmethod
-    def import_bsbound_data(root_block):
+    def import_bsbound_data(self, root_block):
         for n_extra in root_block.get_extra_datas():
             if isinstance(n_extra, NifFormat.BSBound):
-                self.boundhelper.import_bounding_box(n_extra)
+                self.nif_import.boundhelper.import_bounding_box(n_extra)
                     
     @staticmethod    
     def import_bsxflag_data(root_block):

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -49,14 +49,7 @@ class Object:
     # this will have to deal with all naming issues
     def __init__(self, parent):
         self.nif_import = parent
-        # self.dict_names = {}
-        # self.dict_blocks = {}
-    
-    def import_bsbound_data(self, root_block):
-        for n_extra in root_block.get_extra_datas():
-            if isinstance(n_extra, NifFormat.BSBound):
-                self.nif_import.boundhelper.import_bounding_box(n_extra)
-                    
+      
     @staticmethod    
     def import_bsxflag_data(root_block):
         for n_extra in root_block.get_extra_datas():

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -127,7 +127,7 @@ class Object:
             # none exists, create one
             else:
                 b_obj_camera_data = bpy.data.cameras.new("Camera")
-                b_obj_camera = self.objecthelper.create_b_obj(None, b_obj_camera_data)
+                b_obj_camera = self.create_b_obj(None, b_obj_camera_data)
             # make b_obj track camera object
             constr = b_obj.constraints.new('TRACK_TO')
             constr.target = b_obj_camera

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -43,6 +43,7 @@ import mathutils
 from pyffi.formats.nif import NifFormat
 
 from io_scene_nif.modules import armature
+from io_scene_nif.utility.nif_logging import NifLog
 
 class Object:
     # this will have to deal with all naming issues
@@ -94,7 +95,7 @@ class Object:
         """Save original name as object property, for export"""
         if b_obj.name != n_name:
             b_obj.niftools.longname = n_name
-            # NifLog.debug("Stored long name for {0}".format(b_obj.name))
+            NifLog.debug("Stored long name for {0}".format(b_obj.name))
    
     def map_names(self, b_obj, n_block):
         """Create mapping between nif and blender names"""
@@ -181,3 +182,73 @@ class Object:
                 b_child.matrix_local = mpi * b_child.matrix_basis
         else:
             raise RuntimeError("Unexpected object type %s" % b_obj.__class__)
+    
+    def get_skin_deformation_from_partition(self, n_geom):
+        """ Workaround because pyffi does not support this skinning method """
+
+        # todo [pyffi] integrate this into pyffi!!!
+        #              so that NiGeometry.get_skin_deformation() deals with this as intended
+
+        # mostly a copy from pyffi...
+        skininst = n_geom.skin_instance
+        skindata = skininst.data
+        skinpartition = skininst.skin_partition
+        skelroot = skininst.skeleton_root
+        vertices = [ NifFormat.Vector3() for i in range(n_geom.data.num_vertices) ]
+        # ignore normals for now, not needed for import
+        sumweights = [ 0.0 for i in range(n_geom.data.num_vertices) ]
+        skin_offset = skindata.get_transform()
+        # store one transform per bone
+        bone_transforms = []
+        for i, bone_block in enumerate(skininst.bones):
+            bonedata = skindata.bone_list[i]
+            bone_offset = bonedata.get_transform()
+            bone_matrix = bone_block.get_transform(skelroot)
+            transform = bone_offset * bone_matrix * skin_offset
+            bone_transforms.append(transform)
+        # now the actual unique bit
+        for block in skinpartition.skin_partition_blocks:
+            # create all vgroups for this block's bones
+            block_bone_transforms = [bone_transforms[i] for i in block.bones]
+
+            # go over each vert in this block
+            for vert_index, vertex_weights, bone_indices in zip(block.vertex_map,
+                                                                block.vertex_weights,
+                                                                block.bone_indices):
+                # skip verts that were already processed in an earlier block
+                if sumweights[vert_index] != 0:
+                    continue
+                # go over all 4 weight / bone pairs and transform this vert
+                for weight, b_i in zip(vertex_weights, bone_indices):
+                    if weight > 0:
+                        transform = block_bone_transforms[b_i]
+                        vertices[vert_index] += weight * (n_geom.data.vertices[vert_index] * transform)
+                        sumweights[vert_index] += weight
+        for i, s in enumerate(sumweights):
+            if abs(s - 1.0) > 0.01: 
+                print( "vertex %i has weights not summing to one: %i" % (i, sumweights[i]))
+            
+        return vertices
+
+    def apply_skin_deformation(self, n_data):
+        """ Process all geometries in NIF tree to apply their skin """
+        for n_geom in n_data.get_global_iterator():
+            if not isinstance(n_geom, NifFormat.NiGeometry):
+                continue
+            if not n_geom.is_skin():
+                continue
+            NifLog.info('Applying skin deformation on geometry {0}'.format(n_geom.name))
+            skininst = n_geom.skin_instance
+            skindata = skininst.data
+            if skindata.has_vertex_weights:
+                vertices = n_geom.get_skin_deformation()[0]
+            else:
+                NifLog.info("PYFFI does not support this type of skinning, so here's a workaround...")
+                vertices = self.get_skin_deformation_from_partition(n_geom)
+            # finally we can actually set the data
+            for vold, vnew in zip(n_geom.data.vertices, vertices):
+                vold.x = vnew.x
+                vold.y = vnew.y
+                vold.z = vnew.z
+
+                

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -83,7 +83,6 @@ class Object:
         bpy.context.scene.objects.link(b_obj)
         bpy.context.scene.objects.active = b_obj
         self.store_longname(b_obj, n_name)
-        self.map_names(b_obj, n_block)
         return b_obj
 
     def mesh_from_data(self, name, verts, faces):
@@ -107,13 +106,6 @@ class Object:
             b_obj.niftools.longname = n_name
             NifLog.debug("Stored long name for {0}".format(b_obj.name))
    
-    def map_names(self, b_obj, n_block):
-        """Create mapping between nif and blender names"""
-        # map nif block to blender short name
-        self.nif_import.dict_names[n_block] = b_obj.name
-        # map blender short name to nif block
-        self.nif_import.dict_blocks[b_obj.name] = n_block
-        
     def import_range_lod_data(self, n_node, b_obj, b_children):
         """ Import LOD ranges and mark b_obj as a LOD node """
         if isinstance(n_node, NifFormat.NiLODNode):

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -78,7 +78,7 @@ class Object:
     def create_b_obj(self, n_block, b_obj_data):
         """Helper function to create a b_obj from b_obj_data, link it to the current scene, make it active and select it."""
         # get the actual nif name
-        n_name = n_block.name.decode()
+        n_name = n_block.name.decode() if n_block else ""
         # let blender choose a name
         b_obj = bpy.data.objects.new(n_name, b_obj_data)
         b_obj.select = True

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -102,4 +102,14 @@ class Object:
         # map blender short name to nif block
         self.nif_import.dict_blocks[b_obj.name] = n_block
         
-        
+    def import_range_lod_data(self, n_node, b_obj):
+        """ Import LOD ranges and mark b_obj as a LOD node """
+        b_obj["type"] = "NiLODNode"
+        range_data = n_node
+        # where lodlevels are stored is determined by version number
+        # need more examples - just a guess here
+        if not range_data.lod_levels:
+            range_data = n_node.lod_level_data
+        for lod_level, b_child in zip(range_data.lod_levels, b_obj.children):
+            b_child["near_extent"] = lod_level.near_extent
+            b_child["far_extent"] = lod_level.far_extent

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -232,11 +232,10 @@ class Object:
 
     def apply_skin_deformation(self, n_data):
         """ Process all geometries in NIF tree to apply their skin """
-        for n_geom in n_data.get_global_iterator():
-            if not isinstance(n_geom, NifFormat.NiGeometry):
-                continue
-            if not n_geom.is_skin():
-                continue
+        # get all geometries with skin
+        n_geoms = [g for g in n_data.get_global_iterator() if isinstance(g, NifFormat.NiGeometry) and g.is_skin()]
+        # make sure that each skin is applied only once to avoid distortions when a model is referred to twice
+        for n_geom in set(n_geoms):
             NifLog.info('Applying skin deformation on geometry {0}'.format(n_geom.name))
             skininst = n_geom.skin_instance
             skindata = skininst.data

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -43,7 +43,12 @@ import mathutils
 from pyffi.formats.nif import NifFormat
 
 
-class NiObject:
+class Object:
+    # this will have to deal with all naming issues
+    def __init__(self, parent):
+        self.nif_import = parent
+        # self.dict_names = {}
+        # self.dict_blocks = {}
     
     @staticmethod
     def import_bsbound_data(root_block):
@@ -69,3 +74,33 @@ class NiObject:
                     upbflags = n_extra.string_data.decode()
                     return upbflags
         return ''
+
+    
+    def create_b_obj(self, n_block, b_obj_data):
+        """Helper function to create a b_obj from b_obj_data, link it to the current scene, make it active and select it."""
+        # get the actual nif name
+        n_name = n_block.name.decode()
+        # let blender choose a name
+        b_obj = bpy.data.objects.new(n_name, b_obj_data)
+        b_obj.select = True
+        # make the object visible and active
+        bpy.context.scene.objects.link(b_obj)
+        bpy.context.scene.objects.active = b_obj
+        self.store_longname(b_obj, n_name)
+        self.map_names(b_obj, n_block)
+        return b_obj
+        
+    def store_longname(self, b_obj, n_name):
+        """Save original name as object property, for export"""
+        if b_obj.name != n_name:
+            b_obj.niftools.longname = n_name
+            # NifLog.debug("Stored long name for {0}".format(b_obj.name))
+   
+    def map_names(self, b_obj, n_block):
+        """Create mapping between nif and blender names"""
+        # map nif block to blender short name
+        self.nif_import.dict_names[n_block] = b_obj.name
+        # map blender short name to nif block
+        self.nif_import.dict_blocks[b_obj.name] = n_block
+        
+        

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -118,7 +118,7 @@ class Object:
 
     def import_billboard(self, n_node, b_obj):
         """ Import a NiBillboardNode """
-        if isinstance(n_node, NifFormat.NiBillboardNode):
+        if isinstance(n_node, NifFormat.NiBillboardNode) and not isinstance(b_obj, bpy.types.Bone):
             # find camera object
             for obj in bpy.context.scene.objects:
                 if obj.type == 'CAMERA':

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -77,10 +77,12 @@ class Object:
         return ''
 
     
-    def create_b_obj(self, n_block, b_obj_data):
+    def create_b_obj(self, n_block, b_obj_data, name=""):
         """Helper function to create a b_obj from b_obj_data, link it to the current scene, make it active and select it."""
         # get the actual nif name
         n_name = n_block.name.decode() if n_block else ""
+        if name:
+            n_name = name
         # let blender choose a name
         b_obj = bpy.data.objects.new(n_name, b_obj_data)
         b_obj.select = True
@@ -90,7 +92,22 @@ class Object:
         self.store_longname(b_obj, n_name)
         self.map_names(b_obj, n_block)
         return b_obj
+
+    def mesh_from_data(self, name, verts, faces):
+        me = bpy.data.meshes.new(name)
+        me.from_pydata(verts, [], faces)
+        me.update()
+        return self.create_b_obj(None, me, name)
         
+    def box_from_extents(self, b_name, minx, maxx, miny, maxy, minz, maxz):
+        verts = []
+        for x in [minx, maxx]:
+            for y in [miny, maxy]:
+                for z in [minz, maxz]:
+                    verts.append( (x,y,z) )
+        faces = [[0,1,3,2],[6,7,5,4],[0,2,6,4],[3,1,5,7],[4,5,1,0],[7,6,2,3]]
+        return self.mesh_from_data(b_name, verts, faces)
+
     def store_longname(self, b_obj, n_name):
         """Save original name as object property, for export"""
         if b_obj.name != n_name:

--- a/io_scene_nif/modules/property/material/material_export.py
+++ b/io_scene_nif/modules/property/material/material_export.py
@@ -52,7 +52,7 @@ class Material():
         """Return existing material property with given settings, or create
         a new one if a material property with these settings is not found."""
 
-        # create block (but don't register it yet in self.dict_blocks)
+        # create block
         matprop = NifFormat.NiMaterialProperty()
 
         # list which determines whether the material name is relevant or not
@@ -100,7 +100,7 @@ class Material():
         # search for duplicate
         # (ignore the name string as sometimes import needs to create different
         # materials even when NiMaterialProperty is the same)
-        for block in self.nif_export.dict_blocks:
+        for block in self.nif_export.block_to_obj:
             if not isinstance(block, NifFormat.NiMaterialProperty):
                 continue
 

--- a/io_scene_nif/modules/property/material/material_import.py
+++ b/io_scene_nif/modules/property/material/material_import.py
@@ -105,7 +105,7 @@ class Material():
         
         # name unique material
         name = self.nif_import.import_name(n_mat_prop)
-        if name is None:
+        if not name:
             name = (self.nif_import.active_obj_name + "_nt_mat")
         b_mat = bpy.data.materials.new(name)
         

--- a/io_scene_nif/modules/property/property_export.py
+++ b/io_scene_nif/modules/property/property_export.py
@@ -103,7 +103,7 @@ class ObjectProperty:
         """Return existing alpha property with given flags, or create new one
         if an alpha property with required flags is not found."""
         # search for duplicate
-        for block in self.nif_export.dict_blocks:
+        for block in self.nif_export.block_to_obj:
             if isinstance(block, NifFormat.NiAlphaProperty) and block.flags == flags and block.threshold == threshold:
                 return block
 
@@ -117,7 +117,7 @@ class ObjectProperty:
         """Return existing specular property with given flags, or create new one
         if a specular property with required flags is not found."""
         # search for duplicate
-        for block in self.nif_export.dict_blocks:
+        for block in self.nif_export.block_to_obj:
             if isinstance(block, NifFormat.NiSpecularProperty) and block.flags == flags:
                 return block
 
@@ -130,7 +130,7 @@ class ObjectProperty:
         """Return existing wire property with given flags, or create new one
         if an wire property with required flags is not found."""
         # search for duplicate
-        for block in self.nif_export.dict_blocks:
+        for block in self.nif_export.block_to_obj:
             if isinstance(block, NifFormat.NiWireframeProperty) and block.flags == flags:
                 return block
 
@@ -143,7 +143,7 @@ class ObjectProperty:
         """Return existing stencil property with given flags, or create new one
         if an identical stencil property."""
         # search for duplicate
-        for block in self.nif_export.dict_blocks:
+        for block in self.nif_export.block_to_obj:
             if isinstance(block, NifFormat.NiStencilProperty):
                 # all these blocks have the same setting, no further check
                 # is needed

--- a/io_scene_nif/modules/property/texture/texture_export.py
+++ b/io_scene_nif/modules/property/texture/texture_export.py
@@ -217,7 +217,7 @@ class TextureHelper:
         self.export_nitextureprop_tex_descs(texprop)
 
         # search for duplicate
-        for block in self.nif_export.dict_blocks:
+        for block in self.nif_export.block_to_obj:
             if isinstance(block, NifFormat.NiTexturingProperty) and block.get_hash() == texprop.get_hash():
                 return block
 

--- a/io_scene_nif/modules/property/texture/texture_import.py
+++ b/io_scene_nif/modules/property/texture/texture_import.py
@@ -378,7 +378,7 @@ class Texture():
             return "MIX"
 
     def get_uv_layer_name(self, uvset):
-        return "UVMap.%03i" % uvset if uvset != 0 else "UVMap"
+        return str(uvset)
 
     def get_used_textslots(self, b_mat):
         self.used_slots = [b_texslot for b_texslot in b_mat.texture_slots if

--- a/io_scene_nif/modules/property/texture/texture_writer.py
+++ b/io_scene_nif/modules/property/texture/texture_writer.py
@@ -86,7 +86,7 @@ class TextureWriter():
         srctex.unknown_byte = 1
 
         # search for duplicate
-        for block in self.nif_export.nif_export.dict_blocks:
+        for block in self.nif_export.nif_export.block_to_obj:
             if isinstance(block, NifFormat.NiSourceTexture) and block.get_hash() == srctex.get_hash():
                 return block
 

--- a/io_scene_nif/modules/scene/scene_export.py
+++ b/io_scene_nif/modules/scene/scene_export.py
@@ -38,6 +38,9 @@
 # ***** END LICENSE BLOCK *****
 
 import bpy
+from io_scene_nif.utility.nif_global import NifOp
+from io_scene_nif.utility.nif_logging import NifLog
+from pyffi.formats.nif import NifFormat
 
 user_version = {
     'OBLIVION' : 11,
@@ -50,19 +53,15 @@ user_version_2 = {
     'FALLOUT_3' : 34
 }
 
-def get_version_info(properties):
+def get_version_data():
+    """ Returns NifFormat.Data of the correct version and user versions """
+    game = NifOp.props.game
+    version = NifOp.op.version[game]
+    NifLog.info("Writing NIF version 0x%08X" % version)
 
-    # set user version and user version 2 for export
+    # get user version and user version 2 for export
     b_scene = bpy.context.scene.niftools_scene
+    user_version = b_scene.user_version if b_scene.user_version else user_version.get(game, 0)
+    user_version_2 = b_scene.user_version_2 if b_scene.user_version_2 else user_version_2.get(game, 0)
 
-    if b_scene.user_version == 0:
-        NIF_USER_VERSION = user_version.get(properties.game, 0)
-    else :
-        NIF_USER_VERSION = b_scene.user_version
-
-    if b_scene.user_version_2 == 0:
-        NIF_USER_VERSION_2 = user_version_2.get(properties.game, 0)
-    else:
-        NIF_USER_VERSION_2 = b_scene.user_version_2
-
-    return (NIF_USER_VERSION, NIF_USER_VERSION_2)
+    return version, NifFormat.Data(version, user_version, user_version_2)

--- a/io_scene_nif/modules/scene/scene_export.py
+++ b/io_scene_nif/modules/scene/scene_export.py
@@ -42,13 +42,13 @@ from io_scene_nif.utility.nif_global import NifOp
 from io_scene_nif.utility.nif_logging import NifLog
 from pyffi.formats.nif import NifFormat
 
-user_version = {
+USER_VERSION = {
     'OBLIVION' : 11,
     'FALLOUT_3' : 11,
     'DIVINITY_2' : 131072
 }
 
-user_version_2 = {
+USER_VERSION_2 = {
     'OBLIVION' : 11,
     'FALLOUT_3' : 34
 }
@@ -61,7 +61,7 @@ def get_version_data():
 
     # get user version and user version 2 for export
     b_scene = bpy.context.scene.niftools_scene
-    user_version = b_scene.user_version if b_scene.user_version else user_version.get(game, 0)
-    user_version_2 = b_scene.user_version_2 if b_scene.user_version_2 else user_version_2.get(game, 0)
+    user_version = b_scene.user_version if b_scene.user_version else USER_VERSION.get(game, 0)
+    user_version_2 = b_scene.user_version_2 if b_scene.user_version_2 else USER_VERSION_2.get(game, 0)
 
     return version, NifFormat.Data(version, user_version, user_version_2)

--- a/io_scene_nif/nif_common.py
+++ b/io_scene_nif/nif_common.py
@@ -49,10 +49,6 @@ class NifCommon:
     """Abstract base class for import and export. Contains utility functions
     that are commonly used in both import and export.
     """
-    
-    # dictionary of bones that belong to a certain armature
-    # maps NIF armature name to list of NIF bone name
-    dict_armatures = {}
 
     # dictionary mapping bhkRigidBody objects to objects imported in Blender; 
     # we use this dictionary to set the physics constraints (ragdoll etc)

--- a/io_scene_nif/nif_common.py
+++ b/io_scene_nif/nif_common.py
@@ -49,16 +49,7 @@ class NifCommon:
     """Abstract base class for import and export. Contains utility functions
     that are commonly used in both import and export.
     """
-
-    # dictionary of names, to map NIF blocks to correct Blender names
-    dict_names = {}
-
-    # dictionary of bones, maps Blender name to NIF block
-    dict_blocks = {}
     
-    # keeps track of names of exported blocks, to make sure they are unique
-    dict_block_names = []
-
     # dictionary of materials, to reuse materials
     dict_materials = {}
     

--- a/io_scene_nif/nif_common.py
+++ b/io_scene_nif/nif_common.py
@@ -49,7 +49,14 @@ class NifCommon:
     """Abstract base class for import and export. Contains utility functions
     that are commonly used in both import and export.
     """
-    
+    # used for weapon locations or attachments to a body
+    prn_dict = {"BACK": "BackWeapon",
+                "SIDE": "SideWeapon",
+                "QUIVER": "Quiver",
+                "SHIELD": "Bip01 L ForearmTwist",
+                "HELM": "Bip01 Head",
+                "RING": "Bip01 R Finger1"}
+                
     # dictionary of materials, to reuse materials
     dict_materials = {}
     

--- a/io_scene_nif/nif_common.py
+++ b/io_scene_nif/nif_common.py
@@ -63,12 +63,6 @@ class NifCommon:
     # keeps track of names of exported blocks, to make sure they are unique
     dict_block_names = []
 
-    # bone animation priorities (maps NiNode name to priority number);
-    # priorities are set in import_kf_root and are stored into the name
-    # of a NULL constraint (for lack of something better) in
-    # import_armature
-    dict_bone_priorities = {}
-
     # dictionary of materials, to reuse materials
     dict_materials = {}
     

--- a/io_scene_nif/nif_common.py
+++ b/io_scene_nif/nif_common.py
@@ -50,10 +50,6 @@ class NifCommon:
     that are commonly used in both import and export.
     """
 
-    # dictionary mapping bhkRigidBody objects to objects imported in Blender; 
-    # we use this dictionary to set the physics constraints (ragdoll etc)
-    dict_havok_objects = {}
-    
     # dictionary of names, to map NIF blocks to correct Blender names
     dict_names = {}
 

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -169,6 +169,9 @@ class NifExport(NifCommon):
                         raise nif_utils.NifError("Non-uniform scaling not supported.\n "
                                                  "Workaround: apply size and rotation (CTRL-A) on '%s'." % b_obj.name)
 
+            b_armature = armature.get_armature()
+            armature.set_bone_orientation(b_armature.data.niftools_armature.axis_forward, b_armature.data.niftools_armature.axis_up)
+            
             root_name = filebase
             # get the root object from selected object
             # only export empties, meshes, and armatures
@@ -212,7 +215,7 @@ class NifExport(NifCommon):
             self.version = NifOp.op.version[NifOp.props.game]
             self.user_version, self.user_version_2 = scene_export.get_version_info(NifOp.props)
             #the axes used for bone correction depend on the nif version
-            armature.set_bone_correction_from_version(self.version)
+            # armature.set_bone_correction_from_version(self.version)
 
             # create a nif object
 
@@ -664,7 +667,6 @@ class NifExport(NifCommon):
                         targetname = root_block.name
                     kf_root.target_name = targetname
                     kf_root.string_palette = NifFormat.NiStringPalette()
-                    b_armature = armature.get_armature()
                     # per-node animation
                     if b_armature:
                         for b_bone in b_armature.data.bones:

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -42,7 +42,7 @@ from io_scene_nif.nif_common import NifCommon
 from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.nif_logging import NifLog
 
-from io_scene_nif.modules.animation.animation_export import AnimationHelper
+from io_scene_nif.modules.animation.animation_export import Animation
 from io_scene_nif.modules.collision.collision_export import Collision
 from io_scene_nif.modules.armature.armature_export import Armature
 from io_scene_nif.modules import armature
@@ -85,7 +85,7 @@ class NifExport(NifCommon):
         # Helper systems
         self.collisionhelper = Collision(parent=self)
         self.armaturehelper = Armature(parent=self)
-        self.animationhelper = AnimationHelper(parent=self)
+        self.animationhelper = Animation(parent=self)
         self.propertyhelper = PropertyHelper(parent=self)
         self.constrainthelper = constraint_export(parent=self)
         self.texturehelper = TextureHelper(parent=self)

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -169,7 +169,9 @@ class NifExport(NifCommon):
                                                  "Workaround: apply size and rotation (CTRL-A) on '%s'." % b_obj.name)
 
             b_armature = armature.get_armature()
-            armature.set_bone_orientation(b_armature.data.niftools.axis_forward, b_armature.data.niftools.axis_up)
+            # some scenes may not have an armature, so nothing to do here
+            if b_armature:
+               armature.set_bone_orientation(b_armature.data.niftools.axis_forward, b_armature.data.niftools.axis_up)
             
             root_name = filebase
             # get the root object from selected object

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -202,9 +202,6 @@ class NifExport(NifCommon):
             except NameError:
                 animtxt = None
 
-            # rebuild the full name dictionary from the 'FullNames' text buffer
-            self.objecthelper.rebuild_full_names()
-
             # export nif:
             # -----------
             NifLog.info("Exporting")

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -120,7 +120,6 @@ class NifExport(NifCommon):
         directory = os.path.dirname(NifOp.props.filepath)
         filebase, fileext = os.path.splitext(os.path.basename(NifOp.props.filepath))
 
-        self.dict_armatures = {}
         self.dict_bone_priorities = {}
         self.dict_havok_objects = {}
         self.dict_names = {}

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -211,6 +211,8 @@ class NifExport(NifCommon):
             # TODO Move fully to scene level
             self.version = NifOp.op.version[NifOp.props.game]
             self.user_version, self.user_version_2 = scene_export.get_version_info(NifOp.props)
+            #the axes used for bone correction depend on the nif version
+            armature.set_bone_correction_from_version(self.version)
 
             # create a nif object
 

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -169,7 +169,7 @@ class NifExport(NifCommon):
                                                  "Workaround: apply size and rotation (CTRL-A) on '%s'." % b_obj.name)
 
             b_armature = armature.get_armature()
-            armature.set_bone_orientation(b_armature.data.niftools_armature.axis_forward, b_armature.data.niftools_armature.axis_up)
+            armature.set_bone_orientation(b_armature.data.niftools.axis_forward, b_armature.data.niftools.axis_up)
             
             root_name = filebase
             # get the root object from selected object

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -213,8 +213,6 @@ class NifExport(NifCommon):
             # TODO Move fully to scene level
             self.version = NifOp.op.version[NifOp.props.game]
             self.user_version, self.user_version_2 = scene_export.get_version_info(NifOp.props)
-            #the axes used for bone correction depend on the nif version
-            # armature.set_bone_correction_from_version(self.version)
 
             # create a nif object
 

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -111,7 +111,6 @@ class NifExport(NifCommon):
         filebase, fileext = os.path.splitext(os.path.basename(NifOp.props.filepath))
 
         self.dict_bone_priorities = {}
-        self.dict_havok_objects = {}
         self.block_to_obj = {}
         self.dict_materials = {}
         self.dict_textures = {}
@@ -165,7 +164,7 @@ class NifExport(NifCommon):
             
             # smooth seams of objects
             if NifOp.props.smooth_object_seams:
-                self.objecthelper.mesh_helper.smooth_mesh_seams(bpy.context.scene.objects)
+                self.objecthelper.mesh_helper.smooth_mesh_seams(self.exportable_objects)
                 
             # TODO: use Blender actions for animation groups
             # check for animation groups definition in a text buffer 'Anim'
@@ -174,17 +173,11 @@ class NifExport(NifCommon):
             except NameError:
                 animtxt = None
 
-            # export nif:
-            # -----------
             NifLog.info("Exporting")
 
             # find nif version to write
-            # TODO Move fully to scene level
-            self.version = NifOp.op.version[NifOp.props.game]
-            self.user_version, self.user_version_2 = scene_export.get_version_info(NifOp.props)
-
-            # create a nif object
-
+            self.version, data = scene_export.get_version_data()
+            
             # export the actual root node (the name is fixed later to avoid confusing the
             # exporter with duplicate names)
             root_block = self.objecthelper.export_root_node(filebase)
@@ -375,8 +368,6 @@ class NifExport(NifCommon):
             # export nif file:
             # ----------------
 
-            NifLog.info("Writing NIF version 0x%08X" % self.version)
-
             if NifOp.props.animation != 'ANIM_KF':
                 if NifOp.props.game == 'EMPIRE_EARTH_II':
                     ext = ".nifcache"
@@ -389,7 +380,6 @@ class NifExport(NifCommon):
                     NifLog.warn("Changing extension from {0} to {1} on output file".format(fileext, ext))
                 niffile = os.path.join(directory, filebase + ext)
                 
-                data = NifFormat.Data(version=self.version, user_version=self.user_version, user_version_2=self.user_version_2)
                 data.roots = [root_block]
                 if NifOp.props.game == 'NEOSTEAM':
                     data.modification = "neosteam"
@@ -525,7 +515,6 @@ class NifExport(NifCommon):
                 NifLog.info("Writing {0} file".format(prefix + ext))
 
                 kffile = os.path.join(directory, prefix + filebase + ext)
-                data = NifFormat.Data(version=self.version, user_version=self.user_version, user_version_2=self.user_version_2)
                 data.roots = [kf_root]
                 data.neosteam = (NifOp.props.game == 'NEOSTEAM')
                 stream = open(kffile, "wb")
@@ -565,7 +554,6 @@ class NifExport(NifCommon):
                 NifLog.info("Writing {0} file" .format(prefix + ext))
 
                 xniffile = os.path.join(directory, prefix + filebase + ext)
-                data = NifFormat.Data(version=self.version, user_version=self.user_version, user_version_2=self.user_version_2)
                 data.roots = [root_block]
                 data.neosteam = (NifOp.props.game == 'NEOSTEAM')
                 stream = open(xniffile, "wb")

--- a/io_scene_nif/nif_export.py
+++ b/io_scene_nif/nif_export.py
@@ -639,7 +639,6 @@ class NifExport(NifCommon):
                             ctrl.target = None
                 # oblivion
                 elif NifOp.props.game in ('OBLIVION', 'FALLOUT_3', 'CIVILIZATION_IV', 'ZOO_TYCOON_2', 'FREEDOM_FORCE_VS_THE_3RD_REICH'):
-                    b_armature = armature.get_armature()
                     # TODO [animation] allow for object kf only
                     # create kf root header
                     kf_root = self.objecthelper.create_block("NiControllerSequence")
@@ -652,7 +651,7 @@ class NifExport(NifCommon):
                     kf_root.text_keys = anim_textextra
                     kf_root.cycle_type = NifFormat.CycleType.CYCLE_CLAMP
                     kf_root.frequency = 1.0
-                    kf_root.start_time =(bpy.context.scene.frame_start - 1) * bpy.context.scene.render.fps
+                    kf_root.start_time = bpy.context.scene.frame_start * bpy.context.scene.render.fps
                     kf_root.stop_time = (bpy.context.scene.frame_end - bpy.context.scene.frame_start) * bpy.context.scene.render.fps
                     # quick hack to set correct target name
                     if "Bip01" in b_armature.data.bones:
@@ -663,9 +662,16 @@ class NifExport(NifCommon):
                         targetname = root_block.name
                     kf_root.target_name = targetname
                     kf_root.string_palette = NifFormat.NiStringPalette()
-                    for b_bone in b_armature.data.bones:
-                        # per-node animation
-                        self.animationhelper.export_keyframes(kf_root, b_armature, b_bone)
+                    b_armature = armature.get_armature()
+                    # per-node animation
+                    if b_armature:
+                        for b_bone in b_armature.data.bones:
+                            self.animationhelper.export_keyframes(kf_root, b_armature, b_bone)
+                    # per-object animation
+                    else:
+                        for b_obj in bpy.data.objects:
+                            self.animationhelper.export_keyframes(kf_root, b_obj)
+                        
                     # for node, ctrls in zip(iter(node_kfctrls.keys()), iter(node_kfctrls.values())):
                         # # export a block for every interpolator in every controller
                         # for ctrl in ctrls:

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -378,6 +378,9 @@ class NifImport(NifCommon):
                 # import_armature
                 if NifOp.props.skeleton != "GEOMETRY_ONLY":
                     b_obj = self.armaturehelper.import_armature(niBlock)
+                    # set axis orientation - move to armature module?
+                    b_obj.data.niftools_armature.axis_forward = NifOp.props.axis_forward
+                    b_obj.data.niftools_armature.axis_up = NifOp.props.axis_up
                     b_armature = b_obj
                     n_armature = niBlock
                 else:

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -1153,22 +1153,3 @@ class NifImport(NifCommon):
         return [ child for child in niBlock.children
                  if (isinstance(child, NifFormat.NiTriBasedGeom)
                      and child.name.find(node_name) != -1) ]
-
-
-    def store_names(self):
-        """Stores the original, long object names so that they can be
-        re-exported. In order for this to work it is necessary to mantain the
-        imported names unaltered. Since the text buffer is cleared on each
-        import only the last import will be exported correctly."""
-        # clear the text buffer, or create new buffer
-        try:
-            namestxt = bpy.data.texts["FullNames"]
-            namestxt.clear()
-        except KeyError:
-            namestxt = bpy.data.texts.new("FullNames")
-            
-        # write the names to the text buffer
-        for block, shortname in self.dict_names.items():
-            block_name = block.name.decode()
-            if block_name and shortname != block_name:
-                namestxt.write('%s;%s\n' % (shortname, block_name))

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -945,76 +945,8 @@ class NifImport(NifCommon):
                         tface.image = imgobj
 
         # import skinning info, for meshes affected by bones
-        skininst = niBlock.skin_instance
-        if skininst:
-            skindata = skininst.data
-            bones = skininst.bones
-            # the usual case
-            if skindata.has_vertex_weights:
-                boneWeights = skindata.bone_list
-                for idx, n_bone in enumerate(bones):
-                    # skip empty bones (see pyffi issue #3114079)
-                    if not n_bone:
-                        continue
-                    vertex_weights = boneWeights[idx].vertex_weights
-                    # if we are in import geom only mode we have not stored the bones in the dict
-                    # groupname = self.dict_names[n_bone]
-                    groupname = self.import_name(n_bone)
-                    if not groupname in b_obj.vertex_groups.items():
-                        v_group = b_obj.vertex_groups.new(groupname)
-                    for skinWeight in vertex_weights:
-                        vert = skinWeight.index
-                        weight = skinWeight.weight
-                        v_group.add([v_map[vert]], weight, 'REPLACE')
-            # WLP2 - hides the weights in the partition
-            else:
-                skinpartition = skininst.skin_partition
-                for block in skinpartition.skin_partition_blocks:
-                    # create all vgroups for this block's bones
-                    block_bone_names = [self.import_name(bones[i]) for i in block.bones]
-                    for groupname in block_bone_names:
-                        b_obj.vertex_groups.new(groupname)
+        self.armaturehelper.import_skin(niBlock, b_obj, v_map)
 
-                    # go over each vert in this block
-                    for vert, vertex_weights, bone_indices in zip(block.vertex_map,
-                                                                  block.vertex_weights,
-                                                                  block.bone_indices):
-                        # assign this vert's 4 weights to its 4 vgroups (at max)
-                        for w, b_i in zip(vertex_weights, bone_indices):
-                            if w > 0:
-                                groupname = block_bone_names[b_i]
-                                v_group = b_obj.vertex_groups[groupname]
-                                v_group.add([v_map[vert]], w, 'REPLACE')
-                    
-
-        # import body parts as vertex groups
-        if isinstance(skininst, NifFormat.BSDismemberSkinInstance):
-            skinpart_list = []
-            bodypart_flag = []
-            skinpart = niBlock.get_skin_partition()
-            for bodypart, skinpartblock in zip(
-                skininst.partitions, skinpart.skin_partition_blocks):
-                bodypart_wrap = NifFormat.BSDismemberBodyPartType()
-                bodypart_wrap.set_value(bodypart.body_part)
-                groupname = bodypart_wrap.get_detail_display()
-                # create vertex group if it did not exist yet
-                if not(groupname in b_obj.vertex_groups.items()):
-                    v_group = b_obj.vertex_groups.new(groupname)
-                    skinpart_index = len(skinpart_list)
-                    skinpart_list.append((skinpart_index, groupname))
-                    bodypart_flag.append(bodypart.part_flag)
-                # find vertex indices of this group
-                groupverts = [v_map[v_index]
-                              for v_index in skinpartblock.vertex_map]
-                # create the group
-                v_group.add(groupverts, 1, 'ADD')
-            b_obj.niftools_part_flags_panel.pf_partcount = len(skinpart_list)
-            for i, pl_name in skinpart_list:
-                b_obj_partflag = b_obj.niftools_part_flags.add()
-                # b_obj.niftools_part_flags.pf_partint = (i)
-                b_obj_partflag.name = (pl_name)
-                b_obj_partflag.pf_editorflag = (bodypart_flag[i].pf_editor_visible)
-                b_obj_partflag.pf_startflag = (bodypart_flag[i].pf_start_net_boneset)
         # import morph controller
         if NifOp.props.animation:
             self.animationhelper.object_animation.import_morph_controller(niBlock, b_obj, v_map)

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -668,7 +668,6 @@ class NifImport(NifCommon):
             b_mesh = bpy.data.meshes.new(ni_name)
             # create mesh object and link to data
             b_obj = self.objecthelper.create_b_obj(niBlock, b_mesh)
-            # b_name = self.import_name(niBlock)
             
             # Mesh hidden flag
             if niBlock.flags & 1 == 1:
@@ -692,7 +691,7 @@ class NifImport(NifCommon):
         # shortcut for mesh geometry data
         niData = niBlock.data
         if not niData:
-            raise nif_utils.NifError("no shape data in %s" % b_name)
+            raise nif_utils.NifError("no shape data in %s" % ni_name)
 
         # vertices
         n_verts = niData.vertices

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -93,7 +93,6 @@ class NifImport(NifCommon):
         """Main import function."""
 
         self.dict_armatures = {}
-        self.dict_bone_priorities = {}
         self.dict_havok_objects = {}
         self.dict_names = {}
         self.dict_blocks = {}
@@ -688,11 +687,6 @@ class NifImport(NifCommon):
         bpy.context.scene.objects.link(b_empty)
         b_empty.niftools.bsxflags = self.bsxflags
         b_empty.niftools.objectflags = niBlock.flags
-
-        if niBlock.name in self.dict_bone_priorities:
-            constr = b_empty.constraints.append(
-                bpy.types.Constraint.NULL)
-            constr.name = "priority:%i" % self.dict_bone_priorities[niBlock.name]
         return b_empty
 
     def import_mesh(self, niBlock,
@@ -1232,13 +1226,6 @@ class NifImport(NifCommon):
                 b_mesh.vertices[b_v_index].co[0] = base.x
                 b_mesh.vertices[b_v_index].co[1] = base.y
                 b_mesh.vertices[b_v_index].co[2] = base.z
-
-
-        # import priority if existing
-        if niBlock.name in self.dict_bone_priorities:
-            constr = b_obj.constraints.append(
-                bpy.types.Constraint.NULL)
-            constr.name = "priority:%i" % self.dict_bone_priorities[niBlock.name]
 
         # recalculate mesh to render correctly
         # implementation note: update() without validate() can cause crash

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -749,7 +749,7 @@ class NifImport(NifCommon):
         n_verts = niData.vertices
 
         # polygons
-        poly_gens = [list(tri) for tri in niData.get_triangles()]
+        n_triangles = [list(tri) for tri in niData.get_triangles()]
 
         # "sticky" UV coordinates: these are transformed in Blender UV's
         n_uv = list()
@@ -953,24 +953,24 @@ class NifImport(NifCommon):
         del n_map
 
         # Adds the polygons to the mesh
-        f_map = [None] * len(poly_gens)
+        f_map = [None] * len(n_triangles)
         b_f_index = len(b_mesh.polygons)
         bf2_index = len(b_mesh.polygons)
         bl_index = len(b_mesh.loops)
-        poly_count = len(poly_gens)
+        poly_count = len(n_triangles)
         b_mesh.polygons.add(poly_count)
         b_mesh.loops.add(poly_count * 3)
         num_new_faces = 0  # counter for debugging
         unique_faces = list()  # to avoid duplicate polygons
         tri_point_list = list()
-        for i, f in enumerate(poly_gens):
+        for i, f in enumerate(n_triangles):
             # get face index
             f_verts = [v_map[vert_index] for vert_index in f]
             if tuple(f_verts) in unique_faces:
                 continue
             unique_faces.append(tuple(f_verts))
             f_map[i] = b_f_index
-            tri_point_list.append(len(poly_gens[i]))
+            tri_point_list.append(len(n_triangles[i]))
             ls_list = list()
             b_f_index += 1
             num_new_faces += 1
@@ -982,11 +982,11 @@ class NifImport(NifCommon):
             b_mesh.polygons[f_map[i]].loop_start = ls_list[(f_map[i] - bf2_index)]
             b_mesh.polygons[f_map[i]].loop_total = len(unique_faces[(f_map[i] - bf2_index)])
             l = 0
-            lp_points = [v_map[loop_point] for loop_point in poly_gens[(f_map[i] - bf2_index)]]
-            while l < (len(poly_gens[(f_map[i] - bf2_index)])):
+            lp_points = [v_map[loop_point] for loop_point in n_triangles[(f_map[i] - bf2_index)]]
+            while l < (len(n_triangles[(f_map[i] - bf2_index)])):
                 b_mesh.loops[(l + (bl_index))].vertex_index = lp_points[l]
                 l += 1
-            bl_index += (len(poly_gens[(f_map[i] - bf2_index)]))
+            bl_index += (len(n_triangles[(f_map[i] - bf2_index)]))
             
         # at this point, deleted polygons (degenerate or duplicate)
         # satisfy f_map[i] = None
@@ -1057,7 +1057,7 @@ class NifImport(NifCommon):
                     uv_faces = None
                 if uv_faces:
                     uvl = b_mesh.uv_layers.active.data[:]
-                    for b_f_index, f in enumerate(poly_gens):
+                    for b_f_index, f in enumerate(n_triangles):
                         if b_f_index is None:
                             continue
                         uvlist = f

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -293,7 +293,7 @@ class NifImport(NifCommon):
 
         # store original names for re-export
         if self.dict_names:
-            self.armaturehelper.store_names()
+            self.store_names()
         
         
         # now all havok objects are imported, so we are
@@ -1207,3 +1207,22 @@ class NifImport(NifCommon):
         return [ child for child in niBlock.children
                  if (isinstance(child, NifFormat.NiTriBasedGeom)
                      and child.name.find(node_name) != -1) ]
+
+
+    def store_names(self):
+        """Stores the original, long object names so that they can be
+        re-exported. In order for this to work it is necessary to mantain the
+        imported names unaltered. Since the text buffer is cleared on each
+        import only the last import will be exported correctly."""
+        # clear the text buffer, or create new buffer
+        try:
+            namestxt = bpy.data.texts["FullNames"]
+            namestxt.clear()
+        except KeyError:
+            namestxt = bpy.data.texts.new("FullNames")
+            
+        # write the names to the text buffer
+        for block, shortname in self.dict_names.items():
+            block_name = block.name.decode()
+            if block_name and shortname != block_name:
+                namestxt.write('%s;%s\n' % (shortname, block_name))

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -140,19 +140,7 @@ class NifImport(NifCommon):
             if NifOp.props.send_bones_to_bind_position:
                 pyffi.spells.nif.fix.SpellSendBonesToBindPosition(data=self.data).recurse()
             if NifOp.props.apply_skin_deformation:
-                
-                # TODO Create function & move to object/mesh class
-                for n_geom in self.data.get_global_iterator():
-                    if not isinstance(n_geom, NifFormat.NiGeometry):
-                        continue
-                    if not n_geom.is_skin():
-                        continue
-                    NifLog.info('Applying skin deformation on geometry {0}'.format(n_geom.name))
-                    vertices = n_geom.get_skin_deformation()[0]
-                    for vold, vnew in zip(n_geom.data.vertices, vertices):
-                        vold.x = vnew.x
-                        vold.y = vnew.y
-                        vold.z = vnew.z
+                self.objecthelper.apply_skin_deformation(self.data)
 
             # scale tree
             toaster = pyffi.spells.nif.NifToaster()

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -90,9 +90,6 @@ class NifImport(NifCommon):
         # dictionary mapping bhkRigidBody objects to objects imported in Blender; 
         # we use this dictionary to set the physics constraints (ragdoll etc)
         self.dict_havok_objects = {}
-        self.dict_names = {}
-        self.dict_blocks = {}
-        self.dict_block_names = []
         self.dict_materials = {}
         self.dict_textures = {}
         self.dict_mesh_uvlayers = []

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -551,21 +551,17 @@ class NifImport(NifCommon):
 
             # import extra node data, such as node type
             # (other types should be added here too)
-            if (isinstance(niBlock, NifFormat.NiLODNode)
-                # XXX additional isinstance(b_obj, bpy.types.Object)
-                # XXX is a 'workaround' to the limitation that bones
-                # XXX cannot have properties in Blender 2.4x
-                # XXX (remove this check with Blender 2.5)
-                and isinstance(b_obj, bpy.types.Object)):
-                b_obj.addProperty("Type", "NiLODNode", "STRING")
+            if isinstance(niBlock, NifFormat.NiLODNode):
+                b_obj["type"] = "NiLODNode"
                 # import lod data
-                range_data = niBlock.lod_level_data
-                for lod_level, (n_child, b_child) in zip(
-                    range_data.lod_levels, b_children_list):
-                    b_child.addProperty(
-                        "Near Extent", lod_level.near_extent, "FLOAT")
-                    b_child.addProperty(
-                        "Far Extent", lod_level.far_extent, "FLOAT")
+                range_data = niBlock
+                # where lodlevels are stored seems to be determined by version number? need more examples
+                # just a guess here
+                if not range_data.lod_levels:
+                    range_data = niBlock.lod_level_data
+                for lod_level, (n_child, b_child) in zip(range_data.lod_levels, b_children_list):
+                    b_child["near_extent"] = lod_level.near_extent
+                    b_child["far_extent"] = lod_level.far_extent
 
             return b_obj
         # all else is currently discarded

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -558,7 +558,7 @@ class NifImport(NifCommon):
 
                 # import the animations
                 if NifOp.props.animation:
-                    self.animationhelper.import_object_animation(niBlock, b_obj)
+                    self.animationhelper.armature_animation.import_object_animation(niBlock, b_obj)
                     # import the extras
                     self.animationhelper.import_text_keys(niBlock)
                     # import vis controller

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -602,15 +602,11 @@ class NifImport(NifCommon):
             if b_prop.shader_flags_2._items[sf_index]._value == 1:
                 b_obj.niftools_shader[b_flag_name_2] = True
         
-    def import_name(self, niBlock, max_length=63):
-        """Get unique name for an object, preserving existing names.
-        The maximum name length defaults to 63, since this is the
-        maximum for Blender objects.
+    def import_name(self, niBlock):
+        """Get name of niBlock, ready for blender but not necessarily unique.
 
         :param niBlock: A named nif block.
         :type niBlock: :class:`~pyffi.formats.nif.NifFormat.NiObjectNET`
-        :param max_length: The maximum length of the name.
-        :type max_length: :class:`int`
         """
         if niBlock is None:
             return ""
@@ -624,10 +620,10 @@ class NifImport(NifCommon):
                 niName = "RootCollisionNode"
             else:
                 niName = "noname"
+        # todo[armature] should this be moved into armature?
+        niName = armature.get_bone_name_for_blender(niName)
 
-        shortName = armature.get_bone_name_for_blender(niName)
-
-        return shortName
+        return niName
     
     def import_empty(self, niBlock):
         """Creates and returns a grouping empty."""

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -518,21 +518,15 @@ class NifImport(NifCommon):
                     if obj.type == 'CAMERA':
                         b_obj_camera = obj
                         break
+                # none exists, create one
                 else:
-                    raise nif_utils.NifError(
-                        "Scene needs camera for billboard node"
-                        " (add a camera and try again)")
+                    b_obj_camera_data = bpy.data.cameras.new("Camera")
+                    b_obj_camera = self.objecthelper.create_b_obj(None, b_obj_camera_data)
                 # make b_obj track camera object
-                # b_obj.setEuler(0,0,0)
-                b_obj.constraints.new('TRACK_TO')
-                constr = b_obj.constraints[-1]
+                constr = b_obj.constraints.new('TRACK_TO')
                 constr.target = b_obj_camera
-                if constr.target == None:
-                    NifLog.warn("Constraint for billboard node on {0} added but target not set due to transform bug. Set target to Camera manually.".format(b_obj))
                 constr.track_axis = 'TRACK_Z'
                 constr.up_axis = 'UP_Y'
-                # yields transform bug!
-                # constr[Blender.Constraint.Settings.TARGET] = obj
 
             # set object transform
             # this must be done after all children objects have been

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -358,8 +358,8 @@ class NifImport(NifCommon):
                 if NifOp.props.skeleton != "GEOMETRY_ONLY":
                     b_obj = self.armaturehelper.import_armature(niBlock)
                     # set axis orientation - move to armature module?
-                    b_obj.data.niftools_armature.axis_forward = NifOp.props.axis_forward
-                    b_obj.data.niftools_armature.axis_up = NifOp.props.axis_up
+                    b_obj.data.niftools.axis_forward = NifOp.props.axis_forward
+                    b_obj.data.niftools.axis_up = NifOp.props.axis_up
                     b_armature = b_obj
                     n_armature = niBlock
                 else:

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -1160,15 +1160,9 @@ class NifImport(NifCommon):
             asym_morphs = [list(morph.get_relative_vertices())
                           for morph in self.egmdata.asym_morphs]
 
-            # insert base key at frame 1, using relative keys
+            # insert base key at frame 1, using absolute keys
             sk_basis = b_obj.shape_key_add("Basis")
-			# b_mesh.shape_keys.use_relative = False
-
-            # if self.IMPORT_EGMANIM:
-                # # if morphs are animated: create key ipo for mesh
-                # b_ipo = Blender.Ipo.New('Key' , 'KeyIpo')
-                # b_mesh.key.ipo = b_ipo
-
+            b_mesh.shape_keys.use_relative = False
 
             morphs = ([(morph, "EGM SYM %i" % i)
                        for i, morph in enumerate(sym_morphs)]
@@ -1190,37 +1184,14 @@ class NifImport(NifCommon):
                     if applytransform:
                         v *= transform
                     b_mesh.vertices[b_v_index].co = v
-                # update the mesh and insert key
                 shape_key = b_obj.shape_key_add(keyname, from_mix=False)
 
-                # if self.IMPORT_EGMANIM:
-                    # # set up the ipo key curve
-                    # b_curve = b_ipo.addCurve(keyname)
-                    # # linear interpolation
-                    # b_curve.interpolation = Blender.IpoCurve.InterpTypes.LINEAR
-                    # # constant extrapolation
-                    # b_curve.extend = Blender.IpoCurve.ExtendTypes.CONST
-                    # # set up the curve's control points
-                    # framestart = 1 + len(b_mesh.key.blocks) * 10
-                    # for frame, value in ((framestart, 0),
-                                         # (framestart + 5, self.IMPORT_EGMANIMSCALE),
-                                         # (framestart + 10, 0)):
-                        # b_curve.addBezier((frame, value))
-
-            # if self.IMPORT_EGMANIM:
-                # # set begin and end frame
-                # bpy.context.scene.getRenderingContext().startFrame(1)
-                # bpy.context.scene.getRenderingContext().endFrame(
-                    # 11 + len(b_mesh.key.blocks) * 10)
-
-            # # finally: return to base position
-            # for bv, b_v_index in zip(n_verts, v_map):
-                # base = mathutils.Vector(bv.x, bv.y, bv.z)
-                # if applytransform:
-                    # base *= transform
-                # b_mesh.vertices[b_v_index].co[0] = base.x
-                # b_mesh.vertices[b_v_index].co[1] = base.y
-                # b_mesh.vertices[b_v_index].co[2] = base.z
+            # finally: return to base position
+            for bv, b_v_index in zip(n_verts, v_map):
+                base = mathutils.Vector( (bv.x, bv.y, bv.z) )
+                if applytransform:
+                    base *= transform
+                b_mesh.vertices[b_v_index].co = base
 
         # recalculate mesh to render correctly
         # implementation note: update() without validate() can cause crash

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -556,7 +556,7 @@ class NifImport(NifCommon):
 
                 # import the animations
                 if NifOp.props.animation:
-                    self.animationhelper.set_animation(niBlock, b_obj)
+                    self.animationhelper.import_object_animation(niBlock, b_obj)
                     # import the extras
                     self.animationhelper.import_text_keys(niBlock)
                     # import vis controller

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -65,9 +65,6 @@ from pyffi.formats.nif import NifFormat
 
 class NifImport(NifCommon):
 
-    # degrees to radians conversion constant
-    D2R = 3.14159265358979 / 180.0
-    IMPORT_EXTRANODES = True
     IMPORT_EXPORTEMBEDDEDTEXTURES = False
 
     def __init__(self, operator, context):
@@ -92,7 +89,6 @@ class NifImport(NifCommon):
     def execute(self):
         """Main import function."""
 
-        self.dict_armatures = {}
         self.dict_havok_objects = {}
         self.dict_names = {}
         self.dict_blocks = {}
@@ -365,12 +361,11 @@ class NifImport(NifCommon):
             children = niBlock.children
             # bounding box child?
             bsbound = nif_utils.find_extra(niBlock, NifFormat.BSBound)
-            if not (children
-                    or niBlock.collision_object
-                    or bsbound or niBlock.has_bounding_box
-                    or self.IMPORT_EXTRANODES):
-                # do not import unless the node is "interesting"
-                return None
+            # if not (children
+                    # or niBlock.collision_object
+                    # or bsbound or niBlock.has_bounding_box):
+                # # do not import unless the node is "interesting"
+                # return None
             # import object
             if self.armaturehelper.is_armature_root(niBlock):
                 # all bones in the tree are also imported by

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -118,12 +118,8 @@ class NifImport(NifCommon):
             self.data = NifFile.load_nif(NifOp.props.filepath)
             if NifOp.props.override_scene_info:
                 scene_import.import_version_info(self.data)
-
-            # kf_path = NifOp.props.keyframe_file
-            # if kf_path:
-                # self.kfdata = KFFile.load_kf(kf_path)
-            # else:
-                # self.kfdata = None
+            #the axes used for bone correction depend on the nif version
+            armature.set_bone_correction_from_version(self.data.version)
 
             egm_path = NifOp.props.egm_file
             if egm_path:

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -545,16 +545,7 @@ class NifImport(NifCommon):
             # import extra node data, such as node type
             # (other types should be added here too)
             if isinstance(niBlock, NifFormat.NiLODNode):
-                b_obj["type"] = "NiLODNode"
-                # import lod data
-                range_data = niBlock
-                # where lodlevels are stored seems to be determined by version number? need more examples
-                # just a guess here
-                if not range_data.lod_levels:
-                    range_data = niBlock.lod_level_data
-                for lod_level, (n_child, b_child) in zip(range_data.lod_levels, b_children_list):
-                    b_child["near_extent"] = lod_level.near_extent
-                    b_child["far_extent"] = lod_level.far_extent
+                self.objecthelper.import_range_lod_data(niBlock, b_obj)
 
             return b_obj
         # all else is currently discarded

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -503,14 +503,7 @@ class NifImport(NifCommon):
         n_triangles = [list(tri) for tri in niData.get_triangles()]
 
         # "sticky" UV coordinates: these are transformed in Blender UV's
-        n_uv = list()
-        for i in range(len(niData.uv_sets)):
-            for lw in range(len(niData.uv_sets[i])):
-                n_uvt = list()
-                n_uvt.append(niData.uv_sets[i][lw].u)
-                n_uvt.append(1.0 - (niData.uv_sets[i][lw].v))
-                n_uv.append(tuple(n_uvt))
-        n_uvco = tuple(n_uv)
+        n_uvco = tuple( (lw.u, 1.0-lw.v) for uv_set in niData.uv_sets for lw in uv_set )
 
         # vertex normals
         n_norms = niData.normals

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -1161,12 +1161,13 @@ class NifImport(NifCommon):
                           for morph in self.egmdata.asym_morphs]
 
             # insert base key at frame 1, using relative keys
-            b_mesh.insertKey(1, 'relative')
+            sk_basis = b_obj.shape_key_add("Basis")
+			# b_mesh.shape_keys.use_relative = False
 
-            if self.IMPORT_EGMANIM:
-                # if morphs are animated: create key ipo for mesh
-                b_ipo = Blender.Ipo.New('Key' , 'KeyIpo')
-                b_mesh.key.ipo = b_ipo
+            # if self.IMPORT_EGMANIM:
+                # # if morphs are animated: create key ipo for mesh
+                # b_ipo = Blender.Ipo.New('Key' , 'KeyIpo')
+                # b_mesh.key.ipo = b_ipo
 
 
             morphs = ([(morph, "EGM SYM %i" % i)
@@ -1183,47 +1184,43 @@ class NifImport(NifCommon):
                 # for each vertex calculate the key position from base
                 # pos + delta offset
                 for bv, mv, b_v_index in zip(n_verts, morphverts, v_map):
-                    base = mathutils.Vector(bv.x, bv.y, bv.z)
-                    delta = mathutils.Vector(mv[0], mv[1], mv[2])
+                    base = mathutils.Vector( (bv.x, bv.y, bv.z) )
+                    delta = mathutils.Vector( (mv[0], mv[1], mv[2]) )
                     v = base + delta
                     if applytransform:
                         v *= transform
-                    b_mesh.vertices[b_v_index].co[0] = v.x
-                    b_mesh.vertices[b_v_index].co[1] = v.y
-                    b_mesh.vertices[b_v_index].co[2] = v.z
+                    b_mesh.vertices[b_v_index].co = v
                 # update the mesh and insert key
-                b_mesh.insertKey(1, 'relative')
-                # set name for key
-                b_mesh.key.blocks[-1].name = keyname
+                shape_key = b_obj.shape_key_add(keyname, from_mix=False)
 
-                if self.IMPORT_EGMANIM:
-                    # set up the ipo key curve
-                    b_curve = b_ipo.addCurve(keyname)
-                    # linear interpolation
-                    b_curve.interpolation = Blender.IpoCurve.InterpTypes.LINEAR
-                    # constant extrapolation
-                    b_curve.extend = Blender.IpoCurve.ExtendTypes.CONST
-                    # set up the curve's control points
-                    framestart = 1 + len(b_mesh.key.blocks) * 10
-                    for frame, value in ((framestart, 0),
-                                         (framestart + 5, self.IMPORT_EGMANIMSCALE),
-                                         (framestart + 10, 0)):
-                        b_curve.addBezier((frame, value))
+                # if self.IMPORT_EGMANIM:
+                    # # set up the ipo key curve
+                    # b_curve = b_ipo.addCurve(keyname)
+                    # # linear interpolation
+                    # b_curve.interpolation = Blender.IpoCurve.InterpTypes.LINEAR
+                    # # constant extrapolation
+                    # b_curve.extend = Blender.IpoCurve.ExtendTypes.CONST
+                    # # set up the curve's control points
+                    # framestart = 1 + len(b_mesh.key.blocks) * 10
+                    # for frame, value in ((framestart, 0),
+                                         # (framestart + 5, self.IMPORT_EGMANIMSCALE),
+                                         # (framestart + 10, 0)):
+                        # b_curve.addBezier((frame, value))
 
-            if self.IMPORT_EGMANIM:
-                # set begin and end frame
-                bpy.context.scene.getRenderingContext().startFrame(1)
-                bpy.context.scene.getRenderingContext().endFrame(
-                    11 + len(b_mesh.key.blocks) * 10)
+            # if self.IMPORT_EGMANIM:
+                # # set begin and end frame
+                # bpy.context.scene.getRenderingContext().startFrame(1)
+                # bpy.context.scene.getRenderingContext().endFrame(
+                    # 11 + len(b_mesh.key.blocks) * 10)
 
-            # finally: return to base position
-            for bv, b_v_index in zip(n_verts, v_map):
-                base = mathutils.Vector(bv.x, bv.y, bv.z)
-                if applytransform:
-                    base *= transform
-                b_mesh.vertices[b_v_index].co[0] = base.x
-                b_mesh.vertices[b_v_index].co[1] = base.y
-                b_mesh.vertices[b_v_index].co[2] = base.z
+            # # finally: return to base position
+            # for bv, b_v_index in zip(n_verts, v_map):
+                # base = mathutils.Vector(bv.x, bv.y, bv.z)
+                # if applytransform:
+                    # base *= transform
+                # b_mesh.vertices[b_v_index].co[0] = base.x
+                # b_mesh.vertices[b_v_index].co[1] = base.y
+                # b_mesh.vertices[b_v_index].co[2] = base.z
 
         # recalculate mesh to render correctly
         # implementation note: update() without validate() can cause crash

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -119,11 +119,11 @@ class NifImport(NifCommon):
             if NifOp.props.override_scene_info:
                 scene_import.import_version_info(self.data)
 
-            kf_path = NifOp.props.keyframe_file
-            if kf_path:
-                self.kfdata = KFFile.load_kf(kf_path)
-            else:
-                self.kfdata = None
+            # kf_path = NifOp.props.keyframe_file
+            # if kf_path:
+                # self.kfdata = KFFile.load_kf(kf_path)
+            # else:
+                # self.kfdata = None
 
             egm_path = NifOp.props.egm_file
             if egm_path:
@@ -136,9 +136,8 @@ class NifImport(NifCommon):
             NifLog.info("Importing data")
             # calculate and set frames per second
             if NifOp.props.animation:
-                self.animationhelper.set_frames_per_second(
-                self.data.roots
-                + (self.kfdata.roots if self.kfdata else []) )
+                self.animationhelper.set_frames_per_second(self.data.roots)
+                # + (self.kfdata.roots if self.kfdata else []) )
             
             # merge skeleton roots and transform geometry into the rest pose
             if NifOp.props.merge_skeleton_roots:
@@ -194,10 +193,10 @@ class NifImport(NifCommon):
                                 root.remove_child(child)
                 # import this root block
                 NifLog.debug("Root block: {0}".format(root.get_global_display()))
-                # merge animation from kf tree into nif tree
-                if NifOp.props.animation and self.kfdata:
-                    for kf_root in self.kfdata.roots:
-                        self.animationhelper.import_kf_root(kf_root, root)
+                # # merge animation from kf tree into nif tree
+                # if NifOp.props.animation and self.kfdata:
+                    # for kf_root in self.kfdata.roots:
+                        # self.animationhelper.import_kf_root(kf_root, root)
                 # import the nif tree
                 self.import_root(root)
         finally:

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -508,14 +508,20 @@ class NifImport(NifCommon):
                 
                 # set up transforms
                 for n_child, b_child in object_children:
-                    
                     b_child.parent = b_armature
                     b_child.parent_type = 'BONE'
                     b_child.parent_bone = b_obj.name
-                    #multiply with rotation component of inverse parent matrix
-                    b_child.matrix_local =  b_obj.matrix_local.to_3x3().to_4x4().inverted() * b_child.matrix_basis
-                    #move to bone's head position instead of tail
-                    b_child.location.y -= b_obj.length
+                    
+                    # get the child's final transform in nif coordinate space
+                    n_child_armaturespace_matrix = armature.get_bind_matrix(b_obj) * b_child.matrix_basis
+                    # setting the child's world matrix deals with the bone offset under the hood - very elegant!
+                    b_child.matrix_world = n_child_armaturespace_matrix
+                    
+                    # equivalent to the above but more verbose; keep this here as a reference; might be needed for anims?
+                    # make worldspace matrix relative to blender parent bone and set as child's local matrix
+                    # b_child.matrix_local =  b_obj.matrix_local.inverted() * n_child_armaturespace_matrix
+                    # move child to parent bone's head position instead of tail
+                    # b_child.location.y -= b_obj.length
             else:
                 raise RuntimeError(
                     "Unexpected object type %s" % b_obj.__class__)

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -384,7 +384,7 @@ class NifImport(NifCommon):
 
             # import extra node data, such as node type
             self.objecthelper.import_billboard(niBlock, b_obj)
-            self.objecthelper.import_range_lod_data(niBlock, b_obj)
+            self.objecthelper.import_range_lod_data(niBlock, b_obj, b_children)
             self.objecthelper.import_root_collision(niBlock, b_obj)
             
             # set object transform

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -114,12 +114,12 @@ class NifImport(NifCommon):
                         " 'Import Geometry Only + Parent To Selected Armature'"
                         " mode.")
 
+            #the axes used for bone correction depend on the nif version
+            armature.set_bone_orientation(NifOp.props.axis_forward, NifOp.props.axis_up)
 
             self.data = NifFile.load_nif(NifOp.props.filepath)
             if NifOp.props.override_scene_info:
                 scene_import.import_version_info(self.data)
-            #the axes used for bone correction depend on the nif version
-            armature.set_bone_correction_from_version(self.data.version)
 
             egm_path = NifOp.props.egm_file
             if egm_path:

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -89,6 +89,8 @@ class NifImport(NifCommon):
     def execute(self):
         """Main import function."""
 
+        # dictionary mapping bhkRigidBody objects to objects imported in Blender; 
+        # we use this dictionary to set the physics constraints (ragdoll etc)
         self.dict_havok_objects = {}
         self.dict_names = {}
         self.dict_blocks = {}

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -1150,48 +1150,10 @@ class NifImport(NifCommon):
                 b_obj_partflag.pf_startflag = (bodypart_flag[i].pf_start_net_boneset)
         # import morph controller
         if NifOp.props.animation:
-            self.animationhelper.object_animation.import_mesh_controllers(niBlock, b_obj)
+            self.animationhelper.object_animation.import_morph_controller(niBlock, b_obj, v_map)
         # import facegen morphs
         if self.egmdata:
-            # XXX if there is an egm, the assumption is that there is only one
-            # XXX mesh in the nif
-            sym_morphs = [list(morph.get_relative_vertices())
-                          for morph in self.egmdata.sym_morphs]
-            asym_morphs = [list(morph.get_relative_vertices())
-                          for morph in self.egmdata.asym_morphs]
-
-            # insert base key at frame 1, using absolute keys
-            sk_basis = b_obj.shape_key_add("Basis")
-            b_mesh.shape_keys.use_relative = False
-
-            morphs = ([(morph, "EGM SYM %i" % i)
-                       for i, morph in enumerate(sym_morphs)]
-                      + 
-                      [(morph, "EGM ASYM %i" % i)
-                       for i, morph in enumerate(asym_morphs)])
-
-            for morphverts, keyname in morphs:
-                # length check disabled
-                # as sometimes, oddly, the morph has more vertices...
-                # assert(len(verts) == len(morphverts) == len(v_map))
-
-                # for each vertex calculate the key position from base
-                # pos + delta offset
-                for bv, mv, b_v_index in zip(n_verts, morphverts, v_map):
-                    base = mathutils.Vector( (bv.x, bv.y, bv.z) )
-                    delta = mathutils.Vector( (mv[0], mv[1], mv[2]) )
-                    v = base + delta
-                    if applytransform:
-                        v *= transform
-                    b_mesh.vertices[b_v_index].co = v
-                shape_key = b_obj.shape_key_add(keyname, from_mix=False)
-
-            # finally: return to base position
-            for bv, b_v_index in zip(n_verts, v_map):
-                base = mathutils.Vector( (bv.x, bv.y, bv.z) )
-                if applytransform:
-                    base *= transform
-                b_mesh.vertices[b_v_index].co = base
+            self.animationhelper.object_animation.import_egm_morphs(self.egmdata, b_obj, v_map, n_verts)
 
         # recalculate mesh to render correctly
         # implementation note: update() without validate() can cause crash

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -235,7 +235,6 @@ class NifImport(NifCommon):
 
         # now all havok objects are imported, so we are
         # ready to import the havok constraints
-        self.collisionhelper.get_havok_objects()
         self.constrainthelper.import_bhk_constraints()
 
         # parent selected meshes to imported skeleton

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -360,23 +360,22 @@ class NifImport(NifCommon):
                     # set axis orientation - move to armature module?
                     b_obj.data.niftools.axis_forward = NifOp.props.axis_forward
                     b_obj.data.niftools.axis_up = NifOp.props.axis_up
-                    b_armature = b_obj
-                    n_armature = niBlock
                 else:
+                    n_name = self.import_name(niBlock)
                     b_obj = self.selected_objects[0]
-                    b_armature = b_obj
-                    n_armature = niBlock
-                    NifLog.info("Merging nif tree '{0}' with armature '{1}'".format(niBlock.name, b_obj.name))
-                    if niBlock.name != b_obj.name:
-                        NifLog.warn("Using Nif block '{0}' as armature '{1}' but names do not match".format(niBlock.name, b_obj.name))
+                    NifLog.info("Merging nif tree '{0}' with armature '{1}'".format(n_name, b_obj.name))
+                    if n_name != b_obj.name:
+                        NifLog.warn("Using Nif block '{0}' as armature '{1}' but names do not match".format(n_name, b_obj.name))
+                b_armature = b_obj
+                n_armature = niBlock
                 # armatures cannot group geometries into a single mesh
                 geom_group = []
             elif self.armaturehelper.is_bone(niBlock):
                 # bones have already been imported during import_armature
-                b_obj = b_armature.data.bones[self.dict_names[niBlock]]
-                # bones cannot group geometries into a single mesh
+                b_obj = b_armature.data.bones[self.import_name(niBlock)]
                 b_obj.niftools.bsxflags = self.bsxflags
                 b_obj.niftools.boneflags = niBlock.flags
+                # bones cannot group geometries into a single mesh
                 geom_group = []
             else:
                 # is it a grouping node?
@@ -1038,12 +1037,14 @@ class NifImport(NifCommon):
             skindata = skininst.data
             bones = skininst.bones
             boneWeights = skindata.bone_list
-            for idx, bone in enumerate(bones):
+            for idx, n_bone in enumerate(bones):
                 # skip empty bones (see pyffi issue #3114079)
-                if not bone:
+                if not n_bone:
                     continue
                 vertex_weights = boneWeights[idx].vertex_weights
-                groupname = self.dict_names[bone]
+                # if we are in import geom only mode we have not stored the bones in the dict
+                # groupname = self.dict_names[n_bone]
+                groupname = self.import_name(n_bone)
                 if not groupname in b_obj.vertex_groups.items():
                     v_group = b_obj.vertex_groups.new(groupname)
                 for skinWeight in vertex_weights:

--- a/io_scene_nif/operators/__init__.py
+++ b/io_scene_nif/operators/__init__.py
@@ -37,5 +37,5 @@
 #
 # ***** END LICENSE BLOCK *****
 
-from . import object, geometry, nif_import_op, nif_export_op, nif_common_op, kf_import_op
+from . import object, geometry, nif_import_op, nif_export_op, nif_common_op, kf_import_op#, kf_export_op
 

--- a/io_scene_nif/operators/kf_export_op.py
+++ b/io_scene_nif/operators/kf_export_op.py
@@ -1,0 +1,103 @@
+'''Blender Nif Plugin Main Export operators, function called through Export Menu'''
+
+# ***** BEGIN LICENSE BLOCK *****
+# 
+# Copyright © 2005-2015, NIF File Format Library and Tools contributors.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+# 
+#    * Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+# 
+#    * Neither the name of the NIF File Format Library and Tools
+#      project nor the names of its contributors may be used to endorse
+#      or promote products derived from this software without specific
+#      prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# ***** END LICENSE BLOCK *****
+
+import bpy
+from bpy_extras.io_utils import ExportHelper
+
+from pyffi.formats.nif import NifFormat
+
+from io_scene_nif import kf_export
+
+from .nif_common_op import NifOperatorCommon
+
+def _game_to_enum(game):
+    symbols = ":,'\" +-*!?;./="
+    table = str.maketrans(symbols, "_" * len(symbols))
+    enum = game.upper().translate(table).replace("__", "_")
+    return enum
+
+class KfExportOperator(bpy.types.Operator, ExportHelper, NifOperatorCommon):
+    """Operator for saving a kf file."""
+
+    #: Name of function for calling the kf export operators.
+    bl_idname = "export_scene.kf"
+
+    #: How the kf export operators is labelled in the user interface.
+    bl_label = "Export KF"
+
+    #: Number of blender units per nif unit.
+    scale_correction_export = bpy.props.FloatProperty(
+        name="Scale Correction Export",
+        description="Changes size of mesh from Blender default to nif default.",
+        default=1.0,
+        min=0.01, max=100.0, precision=2)
+
+    #: For which game to export.
+    game = bpy.props.EnumProperty(
+        items=[
+            (_game_to_enum(game), game, "Export for " + game)
+            # implementation note: reversed makes it show alphabetically
+            # (at least with the current blender)
+            for game in reversed(sorted(
+                [x for x in NifFormat.games.keys() if x != '?']))
+            ],
+        name="Game",
+        description="For which game to export.",
+        default='OBLIVION')
+
+    #: Use BSAnimationNode (for Morrowind).
+    bs_animation_node = bpy.props.BoolProperty(
+        name="Use NiBSAnimationNode",
+        description="Use NiBSAnimationNode (for Morrowind).",
+        default=False)
+
+    #: Map game enum to nif version.
+    version = {
+        _game_to_enum(game): versions[-1]
+        for game, versions in NifFormat.games.items() if game != '?'
+        }
+
+    def execute(self, context):
+        """Execute the export operators: first constructs a
+        :class:`~io_scene_nif.nif_export.NifExport` instance and then
+        calls its :meth:`~io_scene_nif.nif_export.NifExport.execute`
+        method.
+        """
+        return kf_export.KfExport(self, context).execute()
+    

--- a/io_scene_nif/operators/kf_import_op.py
+++ b/io_scene_nif/operators/kf_import_op.py
@@ -59,7 +59,7 @@ class KfImportOperator(bpy.types.Operator, ImportHelper, NifOperatorCommon):
         description="Changes size of mesh to fit onto Blender's default grid.",
         default=1.0,
         min=0.01, max=100.0, precision=2)
-		
+        
     #: File name filter for file select dialog.
     filter_glob = bpy.props.StringProperty(
         default="*.kf", options={'HIDDEN'})

--- a/io_scene_nif/operators/nif_import_op.py
+++ b/io_scene_nif/operators/nif_import_op.py
@@ -66,14 +66,6 @@ class NifImportOperator(bpy.types.Operator, ImportHelper, NifOperatorCommon):
         description="This will overwrite any previously stored scene information with the Nif header info.",
         default=True)
 
-    #: Keyframe file for animations.
-    keyframe_file = bpy.props.StringProperty(
-        name="Keyframe File",
-        description="Keyframe file for animations.",
-        maxlen=1024,
-        default="",
-        subtype="FILE_PATH")
-
     #: FaceGen EGM file for morphs.
     egm_file = bpy.props.StringProperty(
         name="FaceGen EGM File",
@@ -118,17 +110,6 @@ class NifImportOperator(bpy.types.Operator, ImportHelper, NifOperatorCommon):
         name="Apply Skin Deformation",
         description="Apply skin deformation to all skinned geometries.",
         default=False)
-
-    #: Re-align Tail bones on import
-    import_realign_bones = bpy.props.EnumProperty(
-        items=(
-            ("1", "Re-Align Tail Bone", "Re-Aligns bone tail on import."),
-            ("2", "Re-Align Tail Bone + Roll", "Re-Align tail bone + roll"),
-            ),
-        name="Align",
-        description="Re-align or Re-Align+Roll",
-        default="1")
-
 
     #: What should be imported.
     skeleton = bpy.props.EnumProperty(

--- a/io_scene_nif/operators/nif_import_op.py
+++ b/io_scene_nif/operators/nif_import_op.py
@@ -38,13 +38,14 @@
 # ***** END LICENSE BLOCK *****
 
 import bpy
-from bpy_extras.io_utils import ImportHelper
+from bpy_extras.io_utils import ImportHelper, orientation_helper_factory
 
 from .nif_common_op import NifOperatorCommon
 
 from io_scene_nif import nif_import
 
-class NifImportOperator(bpy.types.Operator, ImportHelper, NifOperatorCommon):
+OrientationHelper = orientation_helper_factory("OrientationHelper", axis_forward='Z', axis_up='Y')
+class NifImportOperator(bpy.types.Operator, ImportHelper, NifOperatorCommon, OrientationHelper):
     """Operator for loading a nif file."""
 
     #: Name of function for calling the nif export operators.

--- a/io_scene_nif/properties/armature.py
+++ b/io_scene_nif/properties/armature.py
@@ -40,6 +40,7 @@
 import bpy
 from bpy.props import (PointerProperty,
                        IntProperty,
+                       EnumProperty,
                        )
 from bpy.types import PropertyGroup
 
@@ -60,3 +61,40 @@ class BoneProperty(PropertyGroup):
     @classmethod
     def unregister(cls):
         del bpy.types.Bone.niftools_bone
+
+class ArmatureProperty(PropertyGroup):
+    @classmethod
+    def register(cls):
+        bpy.types.Armature.niftools_armature = PointerProperty(
+            name='Niftools Armature Property',
+            description='Additional armature properties used by the Nif File Format',
+            type=cls,
+        )
+
+        cls.axis_forward = EnumProperty(
+                name="Forward",
+                items=(('X', "X Forward", ""),
+                       ('Y', "Y Forward", ""),
+                       ('Z', "Z Forward", ""),
+                       ('-X', "-X Forward", ""),
+                       ('-Y', "-Y Forward", ""),
+                       ('-Z', "-Z Forward", ""),
+                       ),
+                default="X",
+                )
+
+        cls.axis_up = EnumProperty(
+                name="Up",
+                items=(('X', "X Up", ""),
+                       ('Y', "Y Up", ""),
+                       ('Z', "Z Up", ""),
+                       ('-X', "-X Up", ""),
+                       ('-Y', "-Y Up", ""),
+                       ('-Z', "-Z Up", ""),
+                       ),
+                default="Y",
+                )
+
+    @classmethod
+    def unregister(cls):
+        del bpy.types.Armature.niftools_armature

--- a/io_scene_nif/properties/armature.py
+++ b/io_scene_nif/properties/armature.py
@@ -57,6 +57,10 @@ class BoneProperty(PropertyGroup):
             name='Bone Flag',
             default=0
         )
+        cls.bonepriority = IntProperty(
+            name='Bone Priority',
+            default=0
+        )
 
     @classmethod
     def unregister(cls):

--- a/io_scene_nif/properties/armature.py
+++ b/io_scene_nif/properties/armature.py
@@ -41,6 +41,7 @@ import bpy
 from bpy.props import (PointerProperty,
                        IntProperty,
                        EnumProperty,
+                       StringProperty
                        )
 from bpy.types import PropertyGroup
 
@@ -60,6 +61,9 @@ class BoneProperty(PropertyGroup):
         cls.bonepriority = IntProperty(
             name='Bone Priority',
             default=0
+        )
+        cls.longname = StringProperty(
+            name='Nif Long Name'
         )
 
     @classmethod

--- a/io_scene_nif/properties/armature.py
+++ b/io_scene_nif/properties/armature.py
@@ -73,7 +73,7 @@ class BoneProperty(PropertyGroup):
 class ArmatureProperty(PropertyGroup):
     @classmethod
     def register(cls):
-        bpy.types.Armature.niftools_armature = PointerProperty(
+        bpy.types.Armature.niftools = PointerProperty(
             name='Niftools Armature Property',
             description='Additional armature properties used by the Nif File Format',
             type=cls,
@@ -105,4 +105,4 @@ class ArmatureProperty(PropertyGroup):
 
     @classmethod
     def unregister(cls):
-        del bpy.types.Armature.niftools_armature
+        del bpy.types.Armature.niftools

--- a/io_scene_nif/properties/armature.py
+++ b/io_scene_nif/properties/armature.py
@@ -49,7 +49,7 @@ from bpy.types import PropertyGroup
 class BoneProperty(PropertyGroup):
     @classmethod
     def register(cls):
-        bpy.types.Bone.niftools_bone = PointerProperty(
+        bpy.types.Bone.niftools = PointerProperty(
             name='Niftools Bone Property',
             description='Additional bone properties used by the Nif File Format',
             type=cls,
@@ -68,7 +68,7 @@ class BoneProperty(PropertyGroup):
 
     @classmethod
     def unregister(cls):
-        del bpy.types.Bone.niftools_bone
+        del bpy.types.Bone.niftools
 
 class ArmatureProperty(PropertyGroup):
     @classmethod

--- a/io_scene_nif/properties/collision.py
+++ b/io_scene_nif/properties/collision.py
@@ -119,6 +119,13 @@ class CollisionProperty(PropertyGroup):
             # default = 'HAV_MAT_WOOD'
         )
 
+        cls.skyrim_havok_material = EnumProperty(
+            name='Skyrim Havok Material',
+            description='The Shapes material, for Skyrim',
+            items=[(item, item, "", i) for i, item in enumerate(NifFormat.SkyrimHavokMaterial._enumkeys)],
+            # default = 'HAV_MAT_WOOD'
+        )
+
         cls.export_bhklist = BoolProperty(
             name='Export BHKList',
             description='None',

--- a/io_scene_nif/properties/object.py
+++ b/io_scene_nif/properties/object.py
@@ -104,6 +104,12 @@ class ObjectProperty(PropertyGroup):
             default='NiNode',
         )
 
+        cls.prn_location = EnumProperty(
+            name='Weapon Location',
+            description='Attachment point of weapon, for Skyrim, FO3 & Oblivion',
+            items=[(item, item, "", i) for i, item in enumerate(["NONE","BACK","SIDE","QUIVER","SHIELD","HELM","RING"])],
+            # default = 'NONE'
+        )
         cls.bsnumuvset = IntProperty(
             name='BS Num UV Set',
             default=0

--- a/io_scene_nif/ui/armature.py
+++ b/io_scene_nif/ui/armature.py
@@ -54,7 +54,7 @@ class BonePanel(Panel):
 
     def draw(self, context):
         if context.bone:
-            nif_bone_props = context.bone.niftools_bone
+            nif_bone_props = context.bone.niftools
             
             layout = self.layout
             row = layout.column()

--- a/io_scene_nif/ui/armature.py
+++ b/io_scene_nif/ui/armature.py
@@ -41,7 +41,7 @@ import bpy
 from bpy.types import Panel
 
 
-class ArmaturePanel(Panel):
+class BonePanel(Panel):
     bl_label = "Niftools Bone Props"
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
@@ -59,4 +59,23 @@ class ArmaturePanel(Panel):
         row = layout.column()
         
         row.prop(nif_bone_props, "boneflags")
+
+class ArmaturePanel(Panel):
+    bl_label = "Niftools Armature Props"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "data"
+
+    @classmethod
+    def poll(cls, context):
+        return True
+        
+    def draw(self, context):
+        nif_armature_props = context.armature.niftools_armature
+        
+        layout = self.layout
+        row = layout.column()
+        
+        row.prop(nif_armature_props, "axis_forward")
+        row.prop(nif_armature_props, "axis_up")
     

--- a/io_scene_nif/ui/armature.py
+++ b/io_scene_nif/ui/armature.py
@@ -75,7 +75,7 @@ class ArmaturePanel(Panel):
         
     def draw(self, context):
         if context.armature:
-            nif_armature_props = context.armature.niftools_armature
+            nif_armature_props = context.armature.niftools
             
             layout = self.layout
             row = layout.column()

--- a/io_scene_nif/ui/armature.py
+++ b/io_scene_nif/ui/armature.py
@@ -72,11 +72,12 @@ class ArmaturePanel(Panel):
         return True
         
     def draw(self, context):
-        nif_armature_props = context.armature.niftools_armature
-        
-        layout = self.layout
-        row = layout.column()
-        
-        row.prop(nif_armature_props, "axis_forward")
-        row.prop(nif_armature_props, "axis_up")
+        if context.armature:
+            nif_armature_props = context.armature.niftools_armature
+            
+            layout = self.layout
+            row = layout.column()
+            
+            row.prop(nif_armature_props, "axis_forward")
+            row.prop(nif_armature_props, "axis_up")
     

--- a/io_scene_nif/ui/armature.py
+++ b/io_scene_nif/ui/armature.py
@@ -53,13 +53,15 @@ class BonePanel(Panel):
         
 
     def draw(self, context):
-        nif_bone_props = context.bone.niftools_bone
-        
-        layout = self.layout
-        row = layout.column()
-        
-        row.prop(nif_bone_props, "boneflags")
-        row.prop(nif_bone_props, "bonepriority")
+        if context.bone:
+            nif_bone_props = context.bone.niftools_bone
+            
+            layout = self.layout
+            row = layout.column()
+            
+            row.prop(nif_bone_props, "boneflags")
+            row.prop(nif_bone_props, "bonepriority")
+            row.prop(nif_bone_props, "longname")
 
 class ArmaturePanel(Panel):
     bl_label = "Niftools Armature Props"

--- a/io_scene_nif/ui/armature.py
+++ b/io_scene_nif/ui/armature.py
@@ -59,6 +59,7 @@ class BonePanel(Panel):
         row = layout.column()
         
         row.prop(nif_bone_props, "boneflags")
+        row.prop(nif_bone_props, "bonepriority")
 
 class ArmaturePanel(Panel):
     bl_label = "Niftools Armature Props"

--- a/io_scene_nif/ui/collision.py
+++ b/io_scene_nif/ui/collision.py
@@ -78,6 +78,7 @@ class CollisionBoundsPanel(Panel):
         box.prop(col_setting, "max_angular_velocity", text='Max Angular Velocity') # oblivion layer prop
         box.prop(col_setting, "motion_system", text='Motion System') # motion system prop
         box.prop(col_setting, "havok_material", text='Havok Material') # havok material prop
+        box.prop(col_setting, "skyrim_havok_material", text='Skyrim Havok Material') # havok material prop
         
         con_setting = context.active_object.niftools_constraint
                 

--- a/io_scene_nif/ui/object.py
+++ b/io_scene_nif/ui/object.py
@@ -59,6 +59,7 @@ class ObjectPanel(Panel):
         layout = self.layout
         row = layout.column()
         row.prop(nif_obj_props, "rootnode")
+        row.prop(nif_obj_props, "prn_location")
         row.prop(nif_obj_props, "bsnumuvset")
         row.prop(nif_obj_props, "upb")
         row.prop(nif_obj_props, "bsxflags")

--- a/io_scene_nif/utility/nif_utils.py
+++ b/io_scene_nif/utility/nif_utils.py
@@ -39,53 +39,16 @@
 # ***** END LICENSE BLOCK *****
 
 import mathutils
-from bpy_extras.io_utils import axis_conversion
 import math
 
 from io_scene_nif.utility.nif_logging import NifLog
+from io_scene_nif.utility.nif_global import NifOp
 
 
 class NifError(Exception):
     """A simple custom exception class for export errors."""
     pass
 
-
-### do all NIFs use the same coordinate system?
-# ZT2 and other old ones
-correction = axis_conversion( from_forward="X", from_up="Y" ).to_4x4()
-# skyrim
-# correction = axis_conversion( from_forward="Z", from_up="Y" ).to_4x4()
-correction_inv = correction.inverted()
-
-
-def import_keymat(rest_rot_inv, key_matrix):
-    """
-    Handles space conversions for imported keys
-    """
-    return correction * (rest_rot_inv * key_matrix) * correction_inv
-    
-def export_keymat(rest_rot, key_matrix, bone):
-    """
-    Handles space conversions for exported keys
-    """
-    if bone:
-        return rest_rot * (correction_inv * key_matrix * correction)
-    else:
-        return rest_rot * key_matrix
-        
-
-def get_bind_matrix(bone):
-    """
-    Get a nif armature-space matrix from a blender bone.
-    """
-    bind = correction *  correction_inv * bone.matrix_local *  correction
-    if bone.parent:
-        p_bind_restored = correction *  correction_inv * bone.parent.matrix_local *  correction
-        bind = p_bind_restored.inverted() * bind
-    return bind
-
-def nif_bind_to_blender_bind(nif_armature_space_matrix):
-    return correction_inv * correction * nif_armature_space_matrix * correction_inv
 
 def vec_roll_to_mat3(vec, roll):
     #port of the updated C function from armature.c


### PR DESCRIPTION
Not sure if opening a PR is the right thing to do at this stage, but oh well xD

Removes the correction matrix system from NIF import.

Also fixes wrong transforms for objects parented to bones.

@niftools/blender-nif-plugin-reviewer 

# Overview
Builds upon PR #287.

> The whole system of storing bone transformation extra data in a text file is counterintuitive and leads to unexpected results if you add or edit bones in blender.
> 
> Last time I checked, bone heads were positioned by the NIF importer by averaging the position of a bone's children. That distorts the matrices, so a compensation has to be stored for each bone in the extra matrix text file, which would be used to restore NIF matrices for export or anything involving animations.
> 
> Instead, only the transformation of the corresponding NIF node should be used to calculate correct head, tail and roll values for the blender bone. This conversion is reversible, so you can retrieve a corresponding & correct NIF node matrix from any blender bone.
> 
> With a most basic implementation without any fancy math or stored extra matrices, you get something like this:
> ![Imgur](https://i.imgur.com/4KpcX72.gif)
> Animates nicely, but the bone orientations are funky.
> 
> If you add a _constant_ object space and bone space correction matrix to everything (the same for all bones), you compensate for the different coordinate systems used by NIF and blender and get something like this instead:
> ![Imgur](https://i.imgur.com/60PAUcS.gif)
> Nice bones, animates properly, no extra matrices needed.
> 
> I have fully functional implementations of the whole system for Zoo Tycoon 2's inhouse NIF-like format BFB, and an armature-only implementation for standard NIFs, since I never dealt with KF animations. But the system is exactly the same and can be simply dropped in.

## Fixes Known Issues
- #100 Sub Issue : # 16: Bone export missing translation data (possibly fixed before, but clearly no longer a bug)
- #117 Incorrect Object transformation
- #185 Bones import incorrectly : Tail rotation (probably)
- #262 Export sets bone rotations to 0,0,-90 after multiple imports (most probably!)

## Documentation
n/a

## Testing
n/a

### Manual
Import any NIF with a skinned model.

### Automated
n/a

