### PR TITLE
Fix collision / havok materials & pyffi dev compatibility

### DIFF
--- a/io_scene_nif/modules/collision/collision_export.py
+++ b/io_scene_nif/modules/collision/collision_export.py
@@ -270,13 +270,13 @@ class Collision:
             n_bhkrigidbody.unknown_2_shorts[1] = 16336
             n_bhkrigidbody.layer_copy = n_bhkrigidbody.layer
             n_bhkrigidbody.col_filter_copy = n_bhkrigidbody.col_filter
-            n_bhkrigidbody.unknown_7_shorts[0] = 0
-            n_bhkrigidbody.unknown_7_shorts[1] = 21280
-            n_bhkrigidbody.unknown_7_shorts[2] = 4581
-            n_bhkrigidbody.unknown_7_shorts[3] = 62977
-            n_bhkrigidbody.unknown_7_shorts[4] = 65535
-            n_bhkrigidbody.unknown_7_shorts[5] = 44
-            n_bhkrigidbody.unknown_7_shorts[6] = 0
+
+            n_bhkrigidbody.unknown_6_shorts[0] = 21280
+            n_bhkrigidbody.unknown_6_shorts[1] = 4581
+            n_bhkrigidbody.unknown_6_shorts[2] = 62977
+            n_bhkrigidbody.unknown_6_shorts[3] = 65535
+            n_bhkrigidbody.unknown_6_shorts[4] = 44
+            n_bhkrigidbody.unknown_6_shorts[5] = 0
 
             # mass is 1.0 at the moment (unless property was set on import or by the user)
             # will be fixed in update_rigid_bodies()

--- a/io_scene_nif/modules/collision/collision_export.py
+++ b/io_scene_nif/modules/collision/collision_export.py
@@ -192,10 +192,11 @@ class Collision:
                 self.HAVOK_SCALE = self.HAVOK_SCALE
 
         # find physics properties/defaults
-        # n_havok_mat = (b_obj.nifcollision.havok_material, b_obj.nifcollision.skyrim_havok_material)
-        # just hard code to the first entry for now until the version transition is settled
-        # then get it from material name
-        n_havok_mat = (0, 131151687)[0]
+        # get havok material name from material name
+        if b_obj.data.materials:
+            n_havok_mat = b_obj.data.materials[0].name
+        else:
+            n_havok_mat = "HAV_MAT_STONE"
         layer = b_obj.nifcollision.oblivion_layer
         motion_system = b_obj.nifcollision.motion_system
         deactivator_type = b_obj.nifcollision.deactivator_type

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -88,9 +88,16 @@ class Collision:
             for mat_type in ("material", "oblivion_havok_material", "fallout_3_havok_material", "skyrim_havok_material"):
                 havok_material = getattr(n_obj, mat_type, None)
                 if havok_material:
+                    print(havok_material)
                     # todo [collision] fix this
+                    if hasattr(havok_material, "material"):
+                        # havok_material.material is an enum
+                        print(type(havok_material.material))
+                        mat_name = str(havok_material.material)
+                    else:
                     # mat_name = str(havok_material.material)
-                    mat_name = str(havok_material)
+                        mat_name = str(havok_material)
+                    print("mat_name",mat_name)
                     b_mat = get_material(mat_name)
                     b_me.materials.append(b_mat)
 

--- a/io_scene_nif/modules/collision/collision_import.py
+++ b/io_scene_nif/modules/collision/collision_import.py
@@ -85,19 +85,20 @@ class Collision:
         b_obj.game.radius = radius
         b_me = b_obj.data
         if n_obj:
+            # todo [pyffi] nif xml 0.7.1.1 HavokMaterial is a union of 3 enums under the HavokMaterial.material field, probably broken!
+            #              needs union support on pyffi end
             for mat_type in ("material", "oblivion_havok_material", "fallout_3_havok_material", "skyrim_havok_material"):
                 havok_material = getattr(n_obj, mat_type, None)
                 if havok_material:
-                    print(havok_material)
-                    # todo [collision] fix this
                     if hasattr(havok_material, "material"):
-                        # havok_material.material is an enum
-                        print(type(havok_material.material))
-                        mat_name = str(havok_material.material)
+                        # HavokMaterial.material is an enum under the hood
+                        # pyffi exposes it as an int (struct.get_basic_attribute) and returns the enum's default value
+                        # we treat it as if it was non-basic to get the enum itself
+                        mat_enum = havok_material.get_attribute("material")
+                        mat_name = str(mat_enum)
                     else:
-                    # mat_name = str(havok_material.material)
+                        # fallback, not sure if we should do this
                         mat_name = str(havok_material)
-                    print("mat_name",mat_name)
                     b_mat = get_material(mat_name)
                     b_me.materials.append(b_mat)
 


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Fixes issues related to enum access of havok materials in the collision sys

## Fixes Known Issues
[Ordered list of issues fixed by this PR]

## Documentation
[Overview of updates to documentation]

## Testing
[Overview of testing required to ensure functionality is correctly implemented]

### Manual
Manual import of failing files passes

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
Still need long term support for attribute unions, there is still a failure for Skyrim material types.
This is acceptable as all Skyrim code has degraded the code base so preferrable to break support until it can be reimplmented

[CropCarrot01.nif.zip](https://github.com/niftools/blender_nif_plugin/files/4000738/CropCarrot01.nif.zip)