### PR TITLE
Refactor/property system

### DIFF
--- a/io_scene_nif/modules/animation/material_import.py
+++ b/io_scene_nif/modules/animation/material_import.py
@@ -47,7 +47,7 @@ from io_scene_nif.utility.util_logging import NifLog
 
 class MaterialAnimation(Animation):
 
-    def import_material_controllers(self, b_material, n_geom):
+    def import_material_controllers(self, n_geom, b_material):
         """Import material animation data for given geometry."""
         if not NifOp.props.animation:
             return

--- a/io_scene_nif/modules/geometry/mesh/mesh_import.py
+++ b/io_scene_nif/modules/geometry/mesh/mesh_import.py
@@ -45,7 +45,7 @@ from io_scene_nif.modules.armature.armature_import import Armature
 from io_scene_nif.modules.geometry import mesh
 from io_scene_nif.modules.geometry.vertex.vertex_import import Vertex
 from io_scene_nif.modules.property.material.material_import import Material
-from io_scene_nif.modules.property.property_import import Property, MeshProperty
+from io_scene_nif.modules.property.property_import import MeshProperty
 from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.util_global import NifOp, EGMData
 from io_scene_nif.utility.util_logging import NifLog
@@ -55,7 +55,6 @@ class Mesh:
 
     def __init__(self):
         self.materialhelper = Material()
-        self.propertyhelper = Property(self.materialhelper)  # TODO [property] Implement fully generic property helper
         self.morph_anim = MorphAnimation()
 
     def import_mesh(self, n_block, b_obj, transform=None):

--- a/io_scene_nif/modules/geometry/mesh/mesh_import.py
+++ b/io_scene_nif/modules/geometry/mesh/mesh_import.py
@@ -85,9 +85,9 @@ class Mesh:
         # "sticky" UV coordinates: these are transformed in Blender UV's
         n_uvco = tuple(tuple((lw.u, 1.0 - lw.v) for lw in uv_set) for uv_set in n_tri_data.uv_sets)
 
-        # TODO [properties] Move out to object level
-        # self.propertyhelper.process_properties(b_obj.data, n_block)
-        MeshProperty().process_property_list(n_block, b_obj.data)
+        # TODO [properties] Should this be object level process, secondary pass for materials / caching
+        if n_block.properties:
+            MeshProperty().process_property_list(n_block, b_obj.data)
 
         v_map = Mesh.map_n_verts_to_b_verts(b_mesh, n_tri_data, transform)
 

--- a/io_scene_nif/modules/geometry/mesh/mesh_import.py
+++ b/io_scene_nif/modules/geometry/mesh/mesh_import.py
@@ -92,13 +92,8 @@ class Mesh:
 
         bf2_index, f_map = Mesh.add_triangles_to_bmesh(b_mesh, n_triangles, v_map)
 
-        # set face smoothing and material
-        for b_polysmooth_index in f_map:
-            if b_polysmooth_index is None:
-                continue
-            polysmooth = b_mesh.polygons[b_polysmooth_index]
-            polysmooth.use_smooth = True if (n_tri_data.has_normals or n_block.skin_instance) else False
-            polysmooth.material_index = material_index
+        is_smooth = True if (n_tri_data.has_normals or n_block.skin_instance) else False
+        self.set_face_smooth(b_mesh, f_map, is_smooth)
 
         Vertex.map_vertex_colors(b_mesh, n_tri_data, v_map)
 
@@ -122,6 +117,18 @@ class Mesh:
 
         b_mesh.validate()
         b_mesh.update()
+
+    @staticmethod
+    def set_face_smooth(b_mesh, f_map, smooth):
+        """set face smoothing and material"""
+
+        mat_index = b_mesh.materials[-1]
+        for b_polysmooth_index in f_map:
+            if b_polysmooth_index is None:
+                continue
+            polysmooth = b_mesh.polygons[b_polysmooth_index]
+            polysmooth.use_smooth = smooth
+            polysmooth.material_index = mat_index
 
     @staticmethod
     def add_triangles_to_bmesh(b_mesh, n_triangles, v_map):

--- a/io_scene_nif/modules/geometry/mesh/mesh_import.py
+++ b/io_scene_nif/modules/geometry/mesh/mesh_import.py
@@ -45,7 +45,7 @@ from io_scene_nif.modules.armature.armature_import import Armature
 from io_scene_nif.modules.geometry import mesh
 from io_scene_nif.modules.geometry.vertex.vertex_import import Vertex
 from io_scene_nif.modules.property.material.material_import import Material
-from io_scene_nif.modules.property.property_import import Property
+from io_scene_nif.modules.property.property_import import Property, MeshProperty
 from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.util_global import NifOp, EGMData
 from io_scene_nif.utility.util_logging import NifLog
@@ -86,7 +86,8 @@ class Mesh:
         n_uvco = tuple(tuple((lw.u, 1.0 - lw.v) for lw in uv_set) for uv_set in n_tri_data.uv_sets)
 
         # TODO [properties] Move out to object level
-        material, material_index = self.propertyhelper.process_properties(b_obj.data, n_block)
+        # self.propertyhelper.process_properties(b_obj.data, n_block)
+        MeshProperty().process_property_list(n_block, b_obj.data)
 
         v_map = Mesh.map_n_verts_to_b_verts(b_mesh, n_tri_data, transform)
 
@@ -100,7 +101,7 @@ class Mesh:
         Vertex.map_uv_layer(b_mesh, bf2_index, n_triangles, n_uvco, n_tri_data)
 
         # TODO [material][texture] Break out texture/material
-        self.materialhelper.set_material_vertex_mapping(b_mesh, f_map, material, n_uvco)
+        self.materialhelper.set_material_vertex_mapping(b_mesh, f_map, n_uvco)
 
         # import skinning info, for meshes affected by bones
         Armature.import_skin(n_block, b_obj, v_map)
@@ -122,13 +123,12 @@ class Mesh:
     def set_face_smooth(b_mesh, f_map, smooth):
         """set face smoothing and material"""
 
-        mat_index = b_mesh.materials[-1]
-        for b_polysmooth_index in f_map:
-            if b_polysmooth_index is None:
+        for b_poly_index in f_map:
+            if b_poly_index is None:
                 continue
-            polysmooth = b_mesh.polygons[b_polysmooth_index]
-            polysmooth.use_smooth = smooth
-            polysmooth.material_index = mat_index
+            poly = b_mesh.polygons[b_poly_index]
+            poly.use_smooth = smooth
+            poly.material_index = 0  # only one material
 
     @staticmethod
     def add_triangles_to_bmesh(b_mesh, n_triangles, v_map):

--- a/io_scene_nif/modules/geometry/mesh/mesh_import.py
+++ b/io_scene_nif/modules/geometry/mesh/mesh_import.py
@@ -70,13 +70,14 @@ class Mesh:
         """
         assert (isinstance(n_block, NifFormat.NiTriBasedGeom))
 
-        NifLog.info("Importing mesh data for geometry '{0}'".format(n_block.name.decode()))
+        node_name = n_block.name.decode()
+        NifLog.info("Importing mesh data for geometry '{0}'".format(node_name))
         b_mesh = b_obj.data
 
         # shortcut for mesh geometry data
         n_tri_data = n_block.data
         if not n_tri_data:
-            raise nif_utils.NifError("No shape data in {0}".format(n_block.name.decode()))
+            raise nif_utils.NifError("No shape data in {0}".format(node_name))
 
         # polygons
         n_triangles = [list(tri) for tri in n_tri_data.get_triangles()]

--- a/io_scene_nif/modules/property/material/material_import.py
+++ b/io_scene_nif/modules/property/material/material_import.py
@@ -69,7 +69,8 @@ class Material:
                 n_wire_prop.get_hash() if n_wire_prop else None,
                 tuple(extra.get_hash() for extra in extra_datas))
 
-    def set_alpha(self, b_mat, n_alpha_prop):
+    @staticmethod
+    def set_alpha(b_mat, n_alpha_prop):
         NifLog.debug("Alpha prop detected")
         b_mat.use_transparency = True
         # TODO [property][material] map alpha material property value
@@ -142,18 +143,19 @@ class Material:
         self.dict_materials[material_hash] = b_mat
         return b_mat
 
-    def set_material_vertex_mapping(self, b_mesh, f_map, material, n_uvco):
-        if material:
+    def set_material_vertex_mapping(self, b_mesh, f_map, n_uvco):
+        b_mat = b_mesh.materials[0]
+        if b_mat:
             # fix up vertex colors depending on whether we had textures in the material
-            mbasetex = self.texturehelper.has_base_texture(material)
-            mglowtex = self.texturehelper.has_glow_texture(material)
+            mbasetex = self.texturehelper.has_base_texture(b_mat)
+            mglowtex = self.texturehelper.has_glow_texture(b_mat)
             if b_mesh.vertex_colors:
                 if mbasetex or mglowtex:
                     # textured material: vertex colors influence lighting
-                    material.use_vertex_color_light = True
+                    b_mat.use_vertex_color_light = True
                 else:
-                    # non-textured material: vertex colors incluence color
-                    material.use_vertex_color_paint = True
+                    # non-textured material: vertex colors influence color
+                    b_mat.use_vertex_color_paint = True
 
             # if there's a base texture assigned to this material display it in Blender's 3D view, but only if there are UV coordinates
             if mbasetex and mbasetex.texture and n_uvco:

--- a/io_scene_nif/modules/property/material/material_import.py
+++ b/io_scene_nif/modules/property/material/material_import.py
@@ -52,23 +52,6 @@ class Material:
         self.dict_materials = {}
         self.texturehelper = Texture()
 
-    def get_material_hash(self, n_mat_prop, n_texture_prop,
-                          n_alpha_prop, n_specular_prop,
-                          texture_effect, n_wire_prop,
-                          extra_datas):
-        """Helper function for import_material. Returns a key that
-        uniquely identifies a material from its properties. The key
-        ignores the material name as that does not affect the
-        rendering.
-        """
-        return (n_mat_prop.get_hash()[1:] if n_mat_prop else None,  # skip first element, which is name
-                n_texture_prop.get_hash() if n_texture_prop else None,
-                n_alpha_prop.get_hash() if n_alpha_prop else None,
-                n_specular_prop.get_hash() if n_specular_prop else None,
-                texture_effect.get_hash() if texture_effect else None,
-                n_wire_prop.get_hash() if n_wire_prop else None,
-                tuple(extra.get_hash() for extra in extra_datas))
-
     @staticmethod
     def set_alpha(b_mat, n_alpha_prop):
         NifLog.debug("Alpha prop detected")
@@ -80,21 +63,8 @@ class Material:
 
         return b_mat
 
+    """
     def import_material(self, n_mat_prop, n_texture_prop, n_alpha_prop, n_specular_prop, texture_effect, n_wire_prop, extra_datas):
-
-        """Creates and returns a material."""
-        # First check if material has been created before.
-        material_hash = self.get_material_hash(n_mat_prop, n_texture_prop, n_alpha_prop, n_specular_prop, texture_effect, n_wire_prop, extra_datas)
-        try:
-            return self.dict_materials[material_hash]
-        except KeyError:
-            pass
-
-        # name unique material
-        name = Object.import_name(n_mat_prop)
-        if not name:
-            name = bpy.context.scene.objects.active + "_nt_mat"
-        b_mat = bpy.data.materials.new(name)
 
         # texures
         if n_texture_prop:
@@ -103,45 +73,7 @@ class Material:
                 self.texturehelper.import_texture_extra_shader(b_mat, n_texture_prop, extra_datas)
         if texture_effect:
             self.texturehelper.import_texture_effect(b_mat, texture_effect)
-
-        # material based properties
-        if n_mat_prop:
-            # Ambient color
-            self.import_material_ambient(b_mat, n_mat_prop)
-
-            # Diffuse color
-            self.import_material_diffuse(b_mat, n_mat_prop)
-
-            # TODO [property][material] - Detect fallout 3+, use emit multi as a degree of emission
-            #        test some values to find emission maximium. 0-1 -> 0-max_val
-            # Should we factor in blender bounds 0.0 - 2.0
-
-            # Emissive
-            self.import_material_emissive(b_mat, n_mat_prop)
-
-            # gloss
-            b_mat.specular_hardness = n_mat_prop.glossiness
-
-            # Alpha
-            if n_alpha_prop:
-                b_mat = self.set_alpha(b_mat, n_alpha_prop)
-
-            # Specular color
-            self.import_material_specular(b_mat, n_mat_prop)
-
-            # todo [property][specular] Need to see what is actually required here
-            if not n_specular_prop or NifData.data.version != 0x14000004:
-                b_mat.specular_intensity = 0.0  # no specular prop
-            else:
-                b_mat.specular_intensity = 1.0  # Blender multiplies specular color with this value
-
-        # check wireframe property
-        if n_wire_prop:
-            # enable wireframe rendering
-            b_mat.type = 'WIRE'
-
-        self.dict_materials[material_hash] = b_mat
-        return b_mat
+    """
 
     def set_material_vertex_mapping(self, b_mesh, f_map, n_uvco):
         b_mat = b_mesh.materials[0]
@@ -200,7 +132,7 @@ class NiMaterial(Material):
         """Creates and returns a material."""
         # First check if material has been created before.
         # TODO [property][material] Decide whether or not to keep the material hash
-        # material_hash = self.get_material_hash(n_mat_prop, n_texture_prop, n_alpha_prop, n_specular_prop)
+        # material_hash = self.get_material_hash(n_mat_prop, n_texture_prop, n_texture_effect, n_extra_data, n_alpha_prop)
         # try:
         #     return material.DICT_MATERIALS[material_hash]
         # except KeyError:

--- a/io_scene_nif/modules/property/material/material_import.py
+++ b/io_scene_nif/modules/property/material/material_import.py
@@ -106,25 +106,17 @@ class Material:
         # material based properties
         if n_mat_prop:
             # Ambient color
-            b_mat.niftools.ambient_color.r = n_mat_prop.ambient_color.r
-            b_mat.niftools.ambient_color.g = n_mat_prop.ambient_color.g
-            b_mat.niftools.ambient_color.b = n_mat_prop.ambient_color.b
+            self.import_material_ambient(b_mat, n_mat_prop)
 
             # Diffuse color
-            b_mat.diffuse_color.r = n_mat_prop.diffuse_color.r
-            b_mat.diffuse_color.g = n_mat_prop.diffuse_color.g
-            b_mat.diffuse_color.b = n_mat_prop.diffuse_color.b
-            b_mat.diffuse_intensity = 1.0
+            self.import_material_diffuse(b_mat, n_mat_prop)
 
             # TODO [property][material] - Detect fallout 3+, use emit multi as a degree of emission
             #        test some values to find emission maximium. 0-1 -> 0-max_val
             # Should we factor in blender bounds 0.0 - 2.0
 
             # Emissive
-            b_mat.niftools.emissive_color.r = n_mat_prop.emissive_color.r
-            b_mat.niftools.emissive_color.g = n_mat_prop.emissive_color.g
-            b_mat.niftools.emissive_color.b = n_mat_prop.emissive_color.b
-            b_mat.emit = n_mat_prop.emit_multi
+            self.import_material_emissive(b_mat, n_mat_prop)
 
             # gloss
             b_mat.specular_hardness = n_mat_prop.glossiness
@@ -134,11 +126,10 @@ class Material:
                 b_mat = self.set_alpha(b_mat, n_alpha_prop)
 
             # Specular color
-            b_mat.specular_color.r = n_mat_prop.specular_color.r
-            b_mat.specular_color.g = n_mat_prop.specular_color.g
-            b_mat.specular_color.b = n_mat_prop.specular_color.b
+            self.import_material_specular(b_mat, n_mat_prop)
 
-            if (not n_specular_prop) and (NifData.data.version != 0x14000004):
+            # todo [property][specular] Need to see what is actually required here
+            if not n_specular_prop or NifData.data.version != 0x14000004:
                 b_mat.specular_intensity = 0.0  # no specular prop
             else:
                 b_mat.specular_intensity = 1.0  # Blender multiplies specular color with this value
@@ -173,3 +164,70 @@ class Material:
                             continue
                         tface = b_mesh.uv_textures.active.data[b_polyimage_index]
                         tface.image = image
+
+    @staticmethod
+    def import_material_specular(b_mat, n_mat_prop):
+        b_mat.specular_color.r = n_mat_prop.specular_color.r
+        b_mat.specular_color.g = n_mat_prop.specular_color.g
+        b_mat.specular_color.b = n_mat_prop.specular_color.b
+
+    @staticmethod
+    def import_material_emissive(b_mat, n_mat_prop):
+        b_mat.niftools.emissive_color.r = n_mat_prop.emissive_color.r
+        b_mat.niftools.emissive_color.g = n_mat_prop.emissive_color.g
+        b_mat.niftools.emissive_color.b = n_mat_prop.emissive_color.b
+        b_mat.emit = n_mat_prop.emit_multi
+
+    @staticmethod
+    def import_material_diffuse(b_mat, n_mat_prop):
+        b_mat.diffuse_color.r = n_mat_prop.diffuse_color.r
+        b_mat.diffuse_color.g = n_mat_prop.diffuse_color.g
+        b_mat.diffuse_color.b = n_mat_prop.diffuse_color.b
+        b_mat.diffuse_intensity = 1.0
+
+    @staticmethod
+    def import_material_ambient(b_mat, n_mat_prop):
+        b_mat.niftools.ambient_color.r = n_mat_prop.ambient_color.r
+        b_mat.niftools.ambient_color.g = n_mat_prop.ambient_color.g
+        b_mat.niftools.ambient_color.b = n_mat_prop.ambient_color.b
+
+
+class NiMaterial(Material):
+
+    def import_material(self, n_block, b_mat, n_mat_prop):
+        """Creates and returns a material."""
+        # First check if material has been created before.
+        # TODO [property][material] Decide whether or not to keep the material hash
+        # material_hash = self.get_material_hash(n_mat_prop, n_texture_prop, n_alpha_prop, n_specular_prop)
+        # try:
+        #     return material.DICT_MATERIALS[material_hash]
+        # except KeyError:
+        #     pass
+
+        # update material material name
+        name = Object.import_name(n_mat_prop)
+        if name is None:
+            name = (n_block.name.decode() + "_nt_mat")
+        b_mat.name = name
+
+        # Ambient color
+        self.import_material_ambient(b_mat, n_mat_prop)
+
+        # Diffuse color
+        self.import_material_diffuse(b_mat, n_mat_prop)
+
+        # TODO [property][material] Detect fallout 3+, use emit multi as a degree of emission
+        # TODO [property][material] Test some values to find emission maximium. 0-1 -> 0-max_val
+        # TODO [property][material] Should we factor in blender bounds 0.0 - 2.0
+
+        # Emissive
+        self.import_material_emissive(b_mat, n_mat_prop)
+
+        # gloss
+        b_mat.specular_hardness = n_mat_prop.glossiness
+
+        # Specular color
+        self.import_material_specular(b_mat, n_mat_prop)
+        b_mat.specular_intensity = 1.0  # Blender multiplies specular color with this value
+
+        return b_mat

--- a/io_scene_nif/modules/property/property_import.py
+++ b/io_scene_nif/modules/property/property_import.py
@@ -177,7 +177,7 @@ class MeshProperty:
         self.process_property.register(NifFormat.NiSpecularProperty, self.process_nispecular_property)
         self.process_property.register(NifFormat.NiWireframeProperty, self.process_niwireframe_property)
         self.process_property.register(NifFormat.NiMaterialProperty, self.process_nimaterial_property)
-        self.process_property.register(NifFormat.NiAlphaProperty, self.process_nialphs_property)
+        self.process_property.register(NifFormat.NiAlphaProperty, self.process_nialpha_property)
         self.process_property.register(NifFormat.NiTexturingProperty, self.process_nitexturing_property)
         self.process_property.register(NifFormat.NiVertexColorProperty, self.process_nivertexcolor_property)
 
@@ -208,7 +208,7 @@ class MeshProperty:
         if NifData.data.version == 0x14000004:
             b_mat.specular_intensity = 0.0  # no specular prop
 
-    def process_nialphs_property(self, prop):
+    def process_nialpha_property(self, prop):
         """Import a NiAlphaProperty based material"""
         NifLog.debug("NiAlphaProperty property found " + str(prop))
         b_mat = self._find_or_create_material()
@@ -242,7 +242,6 @@ class MeshProperty:
     def _find_or_create_material(self):
         b_mats = self.b_mesh.materials
         if len(b_mats) == 0:
-            # assign to 1st material slot
             NifLog.debug("Creating placeholder material to store properties in")
             b_mat = bpy.data.materials.new("")
             self.b_mesh.materials.append(b_mat)

--- a/io_scene_nif/modules/property/property_import.py
+++ b/io_scene_nif/modules/property/property_import.py
@@ -94,12 +94,12 @@ class MeshProperty:
         self.b_mesh = None
         self.n_block = None
         self.process_property = singledispatch(self.process_property)
-        self.process_property.register(NifFormat.NiStencilProperty, self.process_nistencil_property)
-        self.process_property.register(NifFormat.NiSpecularProperty, self.process_nispecular_property)
-        self.process_property.register(NifFormat.NiWireframeProperty, self.process_niwireframe_property)
         self.process_property.register(NifFormat.NiMaterialProperty, self.process_nimaterial_property)
         self.process_property.register(NifFormat.NiAlphaProperty, self.process_nialpha_property)
         self.process_property.register(NifFormat.NiTexturingProperty, self.process_nitexturing_property)
+        self.process_property.register(NifFormat.NiStencilProperty, self.process_nistencil_property)
+        self.process_property.register(NifFormat.NiSpecularProperty, self.process_nispecular_property)
+        self.process_property.register(NifFormat.NiWireframeProperty, self.process_niwireframe_property)
         self.process_property.register(NifFormat.NiVertexColorProperty, self.process_nivertexcolor_property)
 
     def process_property_list(self, n_block, b_mesh):

--- a/io_scene_nif/modules/property/property_import.py
+++ b/io_scene_nif/modules/property/property_import.py
@@ -44,56 +44,47 @@ import bpy
 from pyffi.formats.nif import NifFormat
 
 from io_scene_nif.modules.animation.material_import import MaterialAnimation
-from io_scene_nif.modules.property import texture
 from io_scene_nif.modules.property.material.material_import import Material, NiMaterial
-from io_scene_nif.modules.property.shader.shader_import import BSShader
-from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.util_global import NifData
 from io_scene_nif.utility.util_logging import NifLog
 
 
-class Property:
+"""
+def process_material(self, n_block, b_mesh):
 
-    def __init__(self, materialhelper):
-        self.materialhelper = materialhelper
-        self.material_anim = MaterialAnimation()
+n_effect_shader_prop = nif_utils.find_property(n_block, NifFormat.BSEffectShaderProperty)
 
-    """
-    def process_material(self, n_block, b_mesh):
+if n_mat_prop or n_effect_shader_prop:  # TODO [shader] or bs_shader_property or bs_effect_shader_property:
 
-        n_effect_shader_prop = nif_utils.find_property(n_block, NifFormat.BSEffectShaderProperty)
+    # extra datas (for sid meier's railroads) that have material info
+    extra_datas = []
+    for extra in n_block.get_extra_datas():
+        if isinstance(extra, NifFormat.NiIntegerExtraData):
+            if extra.name in texture.EXTRA_SHADER_TEXTURES:
+                # yes, it describes the shader slot number
+                extra_datas.append(extra)
 
-        if n_mat_prop or n_effect_shader_prop:  # TODO [shader] or bs_shader_property or bs_effect_shader_property:
-
-            # extra datas (for sid meier's railroads) that have material info
-            extra_datas = []
-            for extra in n_block.get_extra_datas():
-                if isinstance(extra, NifFormat.NiIntegerExtraData):
-                    if extra.name in texture.EXTRA_SHADER_TEXTURES:
-                        # yes, it describes the shader slot number
-                        extra_datas.append(extra)
-
-            # texturing effect for environment map in official files this is activated by a NiTextureEffect child
-            # preceeding the n_block
-            textureEffect = None
-            if isinstance(n_block._parent, NifFormat.NiNode):
-                lastchild = None
-                for child in n_block._parent.children:
-                    if child is n_block:
-                        if isinstance(lastchild, NifFormat.NiTextureEffect):
-                            textureEffect = lastchild
-                        break
-                    lastchild = child
-                else:
-                    raise RuntimeError("texture effect scanning bug")
-                # in some mods the NiTextureEffect child follows the n_block
-                # but it still works because it is listed in the effect list
-                # so handle this case separately
-                if not textureEffect:
-                    for effect in n_block._parent.effects:
-                        if isinstance(effect, NifFormat.NiTextureEffect):
-                            textureEffect = effect
-                            break
+    # texturing effect for environment map in official files this is activated by a NiTextureEffect child
+    # preceeding the n_block
+    textureEffect = None
+    if isinstance(n_block._parent, NifFormat.NiNode):
+        lastchild = None
+        for child in n_block._parent.children:
+            if child is n_block:
+                if isinstance(lastchild, NifFormat.NiTextureEffect):
+                    textureEffect = lastchild
+                break
+            lastchild = child
+        else:
+            raise RuntimeError("texture effect scanning bug")
+        # in some mods the NiTextureEffect child follows the n_block
+        # but it still works because it is listed in the effect list
+        # so handle this case separately
+        if not textureEffect:
+            for effect in n_block._parent.effects:
+                if isinstance(effect, NifFormat.NiTextureEffect):
+                    textureEffect = effect
+                    break
 """
 
 
@@ -151,7 +142,7 @@ class MeshProperty:
         b_mat = self._find_or_create_material()
         b_mat = NiMaterial().import_material(self.n_block, b_mat, prop)
         # TODO [animation][material] merge this call into import_material
-        self.material_anim.import_material_controllers(self.n_block, b_mat)
+        MaterialAnimation().import_material_controllers(self.n_block, b_mat)
 
     def process_nitexturing_property(self, prop):
         """Import a NiTexturingProperty based material"""

--- a/io_scene_nif/modules/property/property_import.py
+++ b/io_scene_nif/modules/property/property_import.py
@@ -45,7 +45,7 @@ from pyffi.formats.nif import NifFormat
 
 from io_scene_nif.modules.animation.material_import import MaterialAnimation
 from io_scene_nif.modules.property import texture
-from io_scene_nif.modules.property.material.material_import import Material
+from io_scene_nif.modules.property.material.material_import import Material, NiMaterial
 from io_scene_nif.modules.property.shader.shader_import import BSShader
 from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.util_global import NifData
@@ -219,7 +219,7 @@ class MeshProperty:
         NifLog.debug("NiMaterialProperty property found " + str(prop))
         b_mat = self._find_or_create_material()
         # todo [material] import
-        # Material().import_material(self.n_block, b_mat, prop)
+        NiMaterial().import_material(self.n_block, b_mat, prop)
 
     def process_nitexturing_property(self, prop):
         """Import a NiTexturingProperty based material"""


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Introduce the new property handling system

## Details
- Introduce the generic property handling system
- Add support for some new Ni*Property types 
- Remove old material code, no longer doing block.find
- Extract out generic material code methods (these will also eventually be reused by BS*Shader** nodes so that we get actual code reuse and separation of concerns) to ensure code is maintainable going forward
- NiTexturingProperty is not supported in this PR.

## Fixes Known Issues
N\A

## Documentation
Existing documentation, no change in user functionality

## Testing
Basic testing for happy code paths, using sample set of nifs for affected functionality

### Manual
Import various nifs that had NI*Property blocks
- NiAlphaProperty
- NiMaterialProperty
- NiVertexColorProperty
- NiStencilProperty
- NiSpecularProperty
- NiWireframeProperty

### Automated
No run

## Additional Information
Note : This does not support texture import as rewrite of the processing system is required. 
The current system is broken anyways, so not losing too much by disabling until a future PR
