### PR TITLE
Refactor/object mesh heirarchy

### DIFF
--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -68,8 +68,7 @@ class Armature:
         This is done outside the normal node tree scan to allow for positioning
         of the bones before skins are attached."""
 
-        # armature_name = block_store.import_name(n_armature)
-        armature_name = n_armature.name.decode()
+        armature_name = block_store.import_name(n_armature)
         b_armature_data = bpy.data.armatures.new(armature_name)
         b_armature_data.draw_type = 'STICK'
 

--- a/io_scene_nif/modules/armature/armature_import.py
+++ b/io_scene_nif/modules/armature/armature_import.py
@@ -46,7 +46,9 @@ from pyffi.formats.nif import NifFormat
 
 from io_scene_nif.modules import armature
 from io_scene_nif.modules.animation.transform_import import TransformAnimation
+from io_scene_nif.modules.object.block_registry import block_store
 from io_scene_nif.modules.object.object_import import Object
+from io_scene_nif.nif_common import NifCommon
 from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.util_logging import NifLog
 from io_scene_nif.utility.util_global import NifOp, NifData
@@ -54,9 +56,7 @@ from io_scene_nif.utility.util_global import NifOp, NifData
 
 class Armature:
 
-    def __init__(self, parent):
-        self.nif_import = parent
-
+    def __init__(self):
         self.transform_anim = TransformAnimation()
         # this is used to hold lists of bones for each armature during mark_armatures_bones
         self.dict_armatures = {}
@@ -68,7 +68,7 @@ class Armature:
         This is done outside the normal node tree scan to allow for positioning
         of the bones before skins are attached."""
 
-        # armature_name = Object.import_name(n_armature)
+        # armature_name = block_store.import_name(n_armature)
         armature_name = n_armature.name.decode()
         b_armature_data = bpy.data.armatures.new(armature_name)
         b_armature_data.draw_type = 'STICK'
@@ -94,7 +94,7 @@ class Armature:
         for bone_name, b_bone in b_armature_obj.data.bones.items():
             n_block = self.name_to_block[bone_name]
             # the property is only available from object mode!
-            Object.store_longname(b_bone, n_block.name.decode())
+            block_store.store_longname(b_bone, n_block.name.decode())
             if NifOp.props.animation:
                 self.transform_anim.import_transforms(n_block, b_armature_obj, bone_name)
 
@@ -106,7 +106,7 @@ class Armature:
         if not self.is_bone(n_block):
             return None
         # bone name
-        bone_name = Object.import_name(n_block)
+        bone_name = block_store.import_name(n_block)
         # create a new bone
         b_edit_bone = b_armature_data.edit_bones.new(bone_name)
         # store nif block for access from object mode
@@ -129,78 +129,6 @@ class Armature:
             self.import_bone(n_child, b_armature_data, n_armature, b_edit_bone)
 
     @staticmethod
-    def import_skin(ni_block, b_obj, v_map):
-        """Import a NiSkinInstance and its contents as vertex groups"""
-        skininst = ni_block.skin_instance
-        if skininst:
-            skindata = skininst.data
-            bones = skininst.bones
-            # the usual case
-            if skindata.has_vertex_weights:
-                bone_weights = skindata.bone_list
-                for idx, n_bone in enumerate(bones):
-                    # skip empty bones (see pyffi issue #3114079)
-                    if not n_bone:
-                        continue
-                    vertex_weights = bone_weights[idx].vertex_weights
-                    group_name = Object.import_name(n_bone)
-                    if group_name not in b_obj.vertex_groups:
-                        v_group = b_obj.vertex_groups.new(group_name)
-                    for skinWeight in vertex_weights:
-                        vert = skinWeight.index
-                        weight = skinWeight.weight
-                        v_group.add([v_map[vert]], weight, 'REPLACE')
-
-            # WLP2 - hides the weights in the partition
-            else:
-                skin_partition = skininst.skin_partition
-                for block in skin_partition.skin_partition_blocks:
-                    # create all vgroups for this block's bones
-                    block_bone_names = [Object.import_name(bones[i]) for i in block.bones]
-                    for group_name in block_bone_names:
-                        b_obj.vertex_groups.new(group_name)
-
-                    # go over each vert in this block
-                    for vert, vertex_weights, bone_indices in zip(block.vertex_map, block.vertex_weights, block.bone_indices):
-
-                        # assign this vert's 4 weights to its 4 vgroups (at max)
-                        for w, b_i in zip(vertex_weights, bone_indices):
-                            if w > 0:
-                                group_name = block_bone_names[b_i]
-                                v_group = b_obj.vertex_groups[group_name]
-                                v_group.add([v_map[vert]], w, 'REPLACE')
-
-        # import body parts as vertex groups
-        if isinstance(skininst, NifFormat.BSDismemberSkinInstance):
-            skinpart_list = []
-            bodypart_flag = []
-            skinpart = ni_block.get_skin_partition()
-            for bodypart, skinpartblock in zip(skininst.partitions, skinpart.skin_partition_blocks):
-                bodypart_wrap = NifFormat.BSDismemberBodyPartType()
-                bodypart_wrap.set_value(bodypart.body_part)
-                group_name = bodypart_wrap.get_detail_display()
-
-                # create vertex group if it did not exist yet
-                if group_name not in b_obj.vertex_groups:
-                    v_group = b_obj.vertex_groups.new(group_name)
-                    skinpart_index = len(skinpart_list)
-                    skinpart_list.append((skinpart_index, group_name))
-                    bodypart_flag.append(bodypart.part_flag)
-
-                # find vertex indices of this group
-                groupverts = [v_map[v_index] for v_index in skinpartblock.vertex_map]
-
-                # create the group
-                v_group.add(groupverts, 1, 'ADD')
-            b_obj.niftools_part_flags_panel.pf_partcount = len(skinpart_list)
-            for i, pl_name in skinpart_list:
-                b_obj_partflag = b_obj.niftools_part_flags.add()
-                # b_obj.niftools_part_flags.pf_partint = (i)
-                b_obj_partflag.name = pl_name
-                b_obj_partflag.pf_editorflag = bodypart_flag[i].pf_editor_visible
-                b_obj_partflag.pf_startflag = bodypart_flag[i].pf_start_net_boneset
-
-    @staticmethod
     def fix_bone_lengths(b_armature_data):
         """Sets all edit_bones to a suitable length."""
         for b_edit_bone in b_armature_data.edit_bones:
@@ -218,16 +146,6 @@ class Armature:
                 else:
                     bone_length = b_edit_bone.parent.length
                 b_edit_bone.length = bone_length
-
-    @staticmethod
-    def append_armature_modifier(b_obj, b_armature):
-        """Append an armature modifier for the object."""
-        if b_obj and b_armature:
-            armature_name = b_armature.name
-            b_mod = b_obj.modifiers.new(armature_name, 'ARMATURE')
-            b_mod.object = b_armature
-            b_mod.use_bone_envelopes = False
-            b_mod.use_vertex_groups = True
 
     def mark_armatures_bones(self, ni_block):
         """Mark armatures and bones by peeking into NiSkinInstance blocks."""
@@ -256,7 +174,7 @@ class Armature:
 
         # attaching to selected armature -> first identify armature and bones
         elif NifOp.props.skeleton == "GEOMETRY_ONLY" and not self.dict_armatures:
-            b_armature_obj = self.nif_import.selected_objects[0]
+            b_armature_obj = NifCommon.SELECTED_OBJECTS[0]
             skelroot = ni_block.find(block_name=b_armature_obj.name)
             if not skelroot:
                 skelroot = ni_block

--- a/io_scene_nif/modules/geometry/mesh/mesh_import.py
+++ b/io_scene_nif/modules/geometry/mesh/mesh_import.py
@@ -41,8 +41,8 @@ import mathutils
 from pyffi.formats.nif import NifFormat
 
 from io_scene_nif.modules.animation.morph_import import MorphAnimation
-from io_scene_nif.modules.armature.armature_import import Armature
 from io_scene_nif.modules.geometry import mesh
+from io_scene_nif.modules.geometry.vertex.skin_import import VertexGroup
 from io_scene_nif.modules.geometry.vertex.vertex_import import Vertex
 from io_scene_nif.modules.property.material.material_import import Material
 from io_scene_nif.modules.property.property_import import MeshProperty
@@ -103,7 +103,7 @@ class Mesh:
         # self.materialhelper.set_material_vertex_mapping(b_mesh, f_map, n_uvco)
 
         # import skinning info, for meshes affected by bones
-        Armature.import_skin(n_block, b_obj, v_map)
+        VertexGroup.import_skin(n_block, b_obj, v_map)
 
         # import morph controller
         if NifOp.props.animation:

--- a/io_scene_nif/modules/geometry/vertex/skin_import.py
+++ b/io_scene_nif/modules/geometry/vertex/skin_import.py
@@ -38,6 +38,7 @@
 # ***** END LICENSE BLOCK *****
 from pyffi.formats.nif import NifFormat
 
+from io_scene_nif.modules.object.block_registry import block_store
 from io_scene_nif.utility.util_logging import NifLog
 
 
@@ -117,3 +118,77 @@ class VertexGroup:
                 vold.x = vnew.x
                 vold.y = vnew.y
                 vold.z = vnew.z
+
+    @staticmethod
+    def import_skin(ni_block, b_obj, v_map):
+        """Import a NiSkinInstance and its contents as vertex groups"""
+        skininst = ni_block.skin_instance
+        if skininst:
+            skindata = skininst.data
+            bones = skininst.bones
+            # the usual case
+            if skindata.has_vertex_weights:
+                bone_weights = skindata.bone_list
+                for idx, n_bone in enumerate(bones):
+                    # skip empty bones (see pyffi issue #3114079)
+                    if not n_bone:
+                        continue
+
+                    vertex_weights = bone_weights[idx].vertex_weights
+                    group_name = block_store.import_name(n_bone)
+                    if group_name not in b_obj.vertex_groups:
+                        v_group = b_obj.vertex_groups.new(group_name)
+
+                    for skinWeight in vertex_weights:
+                        vert = skinWeight.index
+                        weight = skinWeight.weight
+                        v_group.add([v_map[vert]], weight, 'REPLACE')
+
+            # WLP2 - hides the weights in the partition
+            else:
+                skin_partition = skininst.skin_partition
+                for block in skin_partition.skin_partition_blocks:
+                    # create all vgroups for this block's bones
+                    block_bone_names = [block_store.import_name(bones[i]) for i in block.bones]
+                    for group_name in block_bone_names:
+                        b_obj.vertex_groups.new(group_name)
+
+                    # go over each vert in this block
+                    for vert, vertex_weights, bone_indices in zip(block.vertex_map, block.vertex_weights, block.bone_indices):
+
+                        # assign this vert's 4 weights to its 4 vgroups (at max)
+                        for w, b_i in zip(vertex_weights, bone_indices):
+                            if w > 0:
+                                group_name = block_bone_names[b_i]
+                                v_group = b_obj.vertex_groups[group_name]
+                                v_group.add([v_map[vert]], w, 'REPLACE')
+
+        # import body parts as vertex groups
+        if isinstance(skininst, NifFormat.BSDismemberSkinInstance):
+            skinpart_list = []
+            bodypart_flag = []
+            skinpart = ni_block.get_skin_partition()
+            for bodypart, skinpartblock in zip(skininst.partitions, skinpart.skin_partition_blocks):
+                bodypart_wrap = NifFormat.BSDismemberBodyPartType()
+                bodypart_wrap.set_value(bodypart.body_part)
+                group_name = bodypart_wrap.get_detail_display()
+
+                # create vertex group if it did not exist yet
+                if group_name not in b_obj.vertex_groups:
+                    v_group = b_obj.vertex_groups.new(group_name)
+                    skinpart_index = len(skinpart_list)
+                    skinpart_list.append((skinpart_index, group_name))
+                    bodypart_flag.append(bodypart.part_flag)
+
+                # find vertex indices of this group
+                groupverts = [v_map[v_index] for v_index in skinpartblock.vertex_map]
+
+                # create the group
+                v_group.add(groupverts, 1, 'ADD')
+            b_obj.niftools_part_flags_panel.pf_partcount = len(skinpart_list)
+            for i, pl_name in skinpart_list:
+                b_obj_partflag = b_obj.niftools_part_flags.add()
+                # b_obj.niftools_part_flags.pf_partint = (i)
+                b_obj_partflag.name = pl_name
+                b_obj_partflag.pf_editorflag = bodypart_flag[i].pf_editor_visible
+                b_obj_partflag.pf_startflag = bodypart_flag[i].pf_start_net_boneset

--- a/io_scene_nif/modules/object/block_registry.py
+++ b/io_scene_nif/modules/object/block_registry.py
@@ -39,6 +39,7 @@
 
 from pyffi.formats.nif import NifFormat
 
+from io_scene_nif.modules import armature
 from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.util_logging import NifLog
 
@@ -83,6 +84,34 @@ class BlockRegistry:
         except AttributeError:
             raise nif_utils.NifError("'{0}': Unknown block type (this is probably a bug).".format(block_type))
         return self.register_block(block, b_obj)
+
+    @staticmethod
+    def store_longname(b_obj, n_name):
+        """Save original name as object property, for export"""
+        if b_obj.name != n_name:
+            b_obj.niftools.longname = n_name
+            NifLog.debug("Stored long name for {0}".format(b_obj.name))
+
+    @staticmethod
+    def import_name(n_block):
+        """Get name of n_block, ready for blender but not necessarily unique.
+
+        :param n_block: A named nif block.
+        :type n_block: :class:`~pyffi.formats.nif.NifFormat.NiObjectNET`
+        """
+        if n_block is None:
+            return ""
+
+        NifLog.debug("Importing name for {0} block from {1}".format(n_block.__class__.__name__, n_block.name))
+
+        n_name = n_block.name.decode()
+
+        # if name is empty, create something non-empty
+        if not n_name:
+            n_name = "noname"
+        n_name = armature.get_bone_name_for_blender(n_name)
+
+        return n_name
 
 
 block_store = BlockRegistry()

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -41,12 +41,18 @@ import bpy
 from pyffi.formats.nif import NifFormat
 
 from io_scene_nif.modules import armature
+from io_scene_nif.modules.geometry.mesh.mesh_import import Mesh
 from io_scene_nif.modules.object import PRN_DICT
+from io_scene_nif.modules.object.block_registry import block_store
+from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.util_global import NifOp
 from io_scene_nif.utility.util_logging import NifLog
 
 
 class Object:
+
+    def __init__(self):
+        self.mesh = Mesh()
 
     # TODO [property] Add delegate processing
     def import_extra_datas(self, root_block, b_obj):
@@ -91,7 +97,7 @@ class Object:
         # make the object visible and active
         bpy.context.scene.objects.link(b_obj)
         bpy.context.scene.objects.active = b_obj
-        Object.store_longname(b_obj, n_name)
+        block_store.store_longname(b_obj, n_name)
         return b_obj
 
     def mesh_from_data(self, name, verts, faces):
@@ -108,13 +114,6 @@ class Object:
                     verts.append((x, y, z))
         faces = [[0, 1, 3, 2], [6, 7, 5, 4], [0, 2, 6, 4], [3, 1, 5, 7], [4, 5, 1, 0], [7, 6, 2, 3]]
         return self.mesh_from_data(b_name, verts, faces)
-
-    @staticmethod
-    def store_longname(b_obj, n_name):
-        """Save original name as object property, for export"""
-        if b_obj.name != n_name:
-            b_obj.niftools.longname = n_name
-            NifLog.debug("Stored long name for {0}".format(b_obj.name))
 
     def import_root_collision(self, n_node, b_obj):
         """ Import a RootCollisionNode """
@@ -202,26 +201,34 @@ class Object:
 
         return b_obj
 
-    @staticmethod
-    def import_name(n_block):
-        """Get name of n_block, ready for blender but not necessarily unique.
+    def import_group_geometry(self, b_armature, geom_group, n_block):
+        # node groups geometries, so import it as a mesh
+        NifLog.info("Joining geometries {0} to single object '{1}'".format([child.name.decode() for child in geom_group], n_block.name.decode()))
+        b_obj = self.create_mesh_object(n_block)
+        b_obj.matrix_local = nif_utils.import_matrix(n_block)
+        bpy.context.scene.objects.active = b_obj
+        for child in geom_group:
+            self.mesh.import_mesh(child, b_obj)
 
-        :param n_block: A named nif block.
-        :type n_block: :class:`~pyffi.formats.nif.NifFormat.NiObjectNET`
-        """
-        if n_block is None:
-            return ""
+            # store flags etc
+            self.import_object_flags(child, b_obj)
+        # is there skinning on any of the grouped geometries?
+        if any(child.skin_instance for child in geom_group):
+            self.append_armature_modifier(b_obj, b_armature)
+        return b_obj
 
-        NifLog.debug("Importing name for {0} block from {1}".format(n_block.__class__.__name__, n_block.name))
-
-        n_name = n_block.name.decode()
-
-        # if name is empty, create something non-empty
-        if not n_name:
-            n_name = "noname"
-        n_name = armature.get_bone_name_for_blender(n_name)
-
-        return n_name
+    def import_geometry_object(self, b_armature, n_block):
+        # it's a shape node and we're not importing skeleton only
+        b_obj = self.create_mesh_object(n_block)
+        transform = nif_utils.import_matrix(n_block)  # set transform matrix for the mesh
+        self.mesh.import_mesh(n_block, b_obj, transform)
+        bpy.context.scene.objects.active = b_obj
+        # store flags etc
+        self.import_object_flags(n_block, b_obj)
+        # skinning? add armature modifier
+        if n_block.skin_instance:
+            self.append_armature_modifier(b_obj, b_armature)
+        return b_obj
 
     # TODO [object][property] Replace with object level property processing
     @staticmethod
@@ -232,3 +239,13 @@ class Object:
         if n_block.data.consistency_flags in NifFormat.ConsistencyType._enumvalues:
             cf_index = NifFormat.ConsistencyType._enumvalues.index(n_block.data.consistency_flags)
             b_obj.niftools.consistency_flags = NifFormat.ConsistencyType._enumkeys[cf_index]
+
+    @staticmethod
+    def append_armature_modifier(b_obj, b_armature):
+        """Append an armature modifier for the object."""
+        if b_obj and b_armature:
+            armature_name = b_armature.name
+            b_mod = b_obj.modifiers.new(armature_name, 'ARMATURE')
+            b_mod.object = b_armature
+            b_mod.use_bone_envelopes = False
+            b_mod.use_vertex_groups = True

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -100,20 +100,22 @@ class Object:
         block_store.store_longname(b_obj, n_name)
         return b_obj
 
-    def mesh_from_data(self, name, verts, faces):
+    @staticmethod
+    def mesh_from_data(name, verts, faces):
         me = bpy.data.meshes.new(name)
         me.from_pydata(verts, [], faces)
         me.update()
-        return self.create_b_obj(None, me, name)
+        return Object.create_b_obj(None, me, name)
 
-    def box_from_extents(self, b_name, minx, maxx, miny, maxy, minz, maxz):
+    @staticmethod
+    def box_from_extents(b_name, minx, maxx, miny, maxy, minz, maxz):
         verts = []
         for x in [minx, maxx]:
             for y in [miny, maxy]:
                 for z in [minz, maxz]:
                     verts.append((x, y, z))
         faces = [[0, 1, 3, 2], [6, 7, 5, 4], [0, 2, 6, 4], [3, 1, 5, 7], [4, 5, 1, 0], [7, 6, 2, 3]]
-        return self.mesh_from_data(b_name, verts, faces)
+        return Object.mesh_from_data(b_name, verts, faces)
 
     def import_root_collision(self, n_node, b_obj):
         """ Import a RootCollisionNode """

--- a/io_scene_nif/modules/object/object_import.py
+++ b/io_scene_nif/modules/object/object_import.py
@@ -203,19 +203,19 @@ class Object:
 
         return b_obj
 
-    def import_group_geometry(self, b_armature, geom_group, n_block):
+    def import_group_geometry(self, b_armature, n_geoms, n_block):
         # node groups geometries, so import it as a mesh
-        NifLog.info("Joining geometries {0} to single object '{1}'".format([child.name.decode() for child in geom_group], n_block.name.decode()))
+        NifLog.info("Joining geometries {0} to single object '{1}'".format([child.name.decode() for child in n_geoms], n_block.name.decode()))
         b_obj = self.create_mesh_object(n_block)
         b_obj.matrix_local = nif_utils.import_matrix(n_block)
         bpy.context.scene.objects.active = b_obj
-        for child in geom_group:
+        for child in n_geoms:
             self.mesh.import_mesh(child, b_obj)
 
             # store flags etc
             self.import_object_flags(child, b_obj)
         # is there skinning on any of the grouped geometries?
-        if any(child.skin_instance for child in geom_group):
+        if any(child.skin_instance for child in n_geoms):
             self.append_armature_modifier(b_obj, b_armature)
         return b_obj
 

--- a/io_scene_nif/modules/property/material/material_import.py
+++ b/io_scene_nif/modules/property/material/material_import.py
@@ -37,8 +37,7 @@
 #
 # ***** END LICENSE BLOCK *****
 
-
-from io_scene_nif.modules.object.object_import import Object
+from io_scene_nif.modules.object.block_registry import block_store
 from io_scene_nif.utility.util_logging import NifLog
 
 
@@ -135,7 +134,7 @@ class NiMaterial(Material):
         #     pass
 
         # update material material name
-        name = Object.import_name(n_mat_prop)
+        name = block_store.import_name(n_mat_prop)
         if name is None:
             name = (n_block.name.decode() + "_nt_mat")
         b_mat.name = name

--- a/io_scene_nif/modules/property/shader/shader_import.py
+++ b/io_scene_nif/modules/property/shader/shader_import.py
@@ -39,8 +39,8 @@
 import bpy
 from pyffi.formats.nif import NifFormat
 
-from io_scene_nif.modules.object.object_import import Object
-from io_scene_nif.modules.property.texture.texture_import import Texture
+from io_scene_nif.modules.object.block_registry import block_store
+from io_scene_nif.modules.property.texture.texture_import import TextureSlotManager
 from io_scene_nif.utility import nif_utils
 from io_scene_nif.utility.util_logging import NifLog
 
@@ -49,7 +49,7 @@ class BSShader:
 
     def __init__(self):
         self.dict_materials = {}
-        self.texturehelper = Texture()
+        self.texturehelper = TextureSlotManager()
 
     @staticmethod
     def import_shader_types(b_obj, b_prop):
@@ -93,7 +93,7 @@ class BSShader:
             pass
 
         # name unique material
-        name = Object.import_name(bs_shader_property)
+        name = block_store.import_name(bs_shader_property)
         if not name:
             name = bpy.context.scene.objects.active + "_nt_mat"
         b_mat = bpy.data.materials.new(name)

--- a/io_scene_nif/nif_common.py
+++ b/io_scene_nif/nif_common.py
@@ -39,7 +39,6 @@
 
 import bpy
 import pyffi
-from pyffi.formats.nif import NifFormat
 
 from io_scene_nif.utility.util_global import NifOp
 from io_scene_nif.utility.util_logging import NifLog
@@ -50,21 +49,9 @@ class NifCommon:
     that are commonly used in both import and export.
     """
 
-    VERTEX_RESOLUTION = 1000
-    NORMAL_RESOLUTION = 100
-
-    EXTRA_SHADER_TEXTURES = [
-        "EnvironmentMapIndex",
-        "NormalMapIndex",
-        "SpecularIntensityIndex",
-        "EnvironmentIntensityIndex",
-        "LightCubeMapIndex",
-        "ShadowTextureIndex"]
-    """Names (ordered by default index) of shader texture slots for
-    Sid Meier's Railroads and similar games.
-    """
-
     HAVOK_SCALE = 6.996
+
+    SELECTED_OBJECTS = []
 
     def __init__(self, operator, context):
         """Common initialization functions for executing the import/export operators: """
@@ -80,15 +67,4 @@ class NifCommon:
                                                                                                                 pyffi.__version__))
 
         # find and store this list now of selected objects as creating new objects adds them to the selection list
-        self.selected_objects = bpy.context.selected_objects[:]
-
-    def get_n_apply_mode_from_b_blend_type(self, b_blend_type):
-        if b_blend_type == "LIGHTEN":
-            return NifFormat.ApplyMode.APPLY_HILIGHT
-        elif b_blend_type == "MULTIPLY":
-            return NifFormat.ApplyMode.APPLY_HILIGHT2
-        elif b_blend_type == "MIX":
-            return NifFormat.ApplyMode.APPLY_MODULATE
-
-        NifLog.warn("Unsupported blend type ({0}) in material, using apply mode APPLY_MODULATE".format(b_blend_type))
-        return NifFormat.ApplyMode.APPLY_MODULATE
+        NifCommon.SELECTED_OBJECTS = bpy.context.selected_objects[:]

--- a/io_scene_nif/nif_common.py
+++ b/io_scene_nif/nif_common.py
@@ -49,8 +49,6 @@ class NifCommon:
     that are commonly used in both import and export.
     """
 
-    HAVOK_SCALE = 6.996
-
     SELECTED_OBJECTS = []
 
     def __init__(self, operator, context):
@@ -66,5 +64,3 @@ class NifCommon:
                                                                                                                 bpy.app.version_string,
                                                                                                                 pyffi.__version__))
 
-        # find and store this list now of selected objects as creating new objects adds them to the selection list
-        NifCommon.SELECTED_OBJECTS = bpy.context.selected_objects[:]

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -68,20 +68,20 @@ class NifImport(NifCommon):
     def __init__(self, operator, context):
         NifCommon.__init__(self, operator, context)
 
+    def execute(self):
+        """Main import function."""
+        self.load_files()
+
+        # find and store this list now of selected objects as creating new objects adds them to the selection list
+        self.SELECTED_OBJECTS = bpy.context.selected_objects[:]
+
         # Helper systems
         self.armaturehelper = Armature()
-        self.collisionhelper = Collision(parent=self)
-        self.constrainthelper = Constraint(parent=self)
+        self.collisionhelper = Collision()
+        self.constrainthelper = Constraint()
         self.objecthelper = Object()
         self.object_anim = ObjectAnimation()
         self.transform_anim = TransformAnimation()
-
-    def execute(self):
-        """Main import function."""
-
-        # dictionary mapping bhkRigidBody objects to objects imported in Blender; 
-        # we use this dictionary to set the physics constraints (ragdoll etc)
-        self.dict_havok_objects = {}
 
         # catch nif import errors
         try:
@@ -93,8 +93,6 @@ class NifImport(NifCommon):
 
             # the axes used for bone correction depend on the nif version
             armature.set_bone_orientation(NifOp.props.axis_forward, NifOp.props.axis_up)
-
-            self.load_files()
 
             NifLog.info("Importing data")
             # calculate and set frames per second

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -51,11 +51,10 @@ from io_scene_nif.modules.animation.transform_import import TransformAnimation
 from io_scene_nif.modules.armature.armature_import import Armature
 from io_scene_nif.modules.collision.collision_import import Collision
 from io_scene_nif.modules.constraint.constraint_import import Constraint
-from io_scene_nif.modules.geometry.mesh.mesh_import import Mesh
 from io_scene_nif.modules.geometry.vertex.skin_import import VertexGroup
+from io_scene_nif.modules.object.block_registry import block_store
 from io_scene_nif.modules.object.object_import import Object
 from io_scene_nif.modules.object.object_types.type_import import NiTypes
-from io_scene_nif.modules.property.material.material_import import Material
 from io_scene_nif.modules.scene import scene_import
 
 from io_scene_nif.nif_common import NifCommon
@@ -70,11 +69,9 @@ class NifImport(NifCommon):
         NifCommon.__init__(self, operator, context)
 
         # Helper systems
-        self.armaturehelper = Armature(parent=self)
+        self.armaturehelper = Armature()
         self.collisionhelper = Collision(parent=self)
         self.constrainthelper = Constraint(parent=self)
-        self.materialhelper = Material()
-        self.mesh = Mesh()
         self.objecthelper = Object()
         self.object_anim = ObjectAnimation()
         self.transform_anim = TransformAnimation()
@@ -91,7 +88,7 @@ class NifImport(NifCommon):
             # check that one armature is selected in 'import geometry + parent
             # to armature' mode
             if NifOp.props.skeleton == "GEOMETRY_ONLY":
-                if len(self.selected_objects) != 1 or self.selected_objects[0].type != 'ARMATURE':
+                if len(NifCommon.SELECTED_OBJECTS) != 1 or NifCommon.SELECTED_OBJECTS[0].type != 'ARMATURE':
                     raise nif_utils.NifError("You must select exactly one armature in 'Import Geometry Only + Parent To Selected Armature' mode.")
 
             # the axes used for bone correction depend on the nif version
@@ -223,20 +220,7 @@ class NifImport(NifCommon):
         geom_group = []
         NifLog.info("Importing data for block '{0}'".format(n_block.name.decode()))
         if isinstance(n_block, NifFormat.NiTriBasedGeom) and NifOp.props.skeleton != "SKELETON_ONLY":
-            # it's a shape node and we're not importing skeleton only
-            b_obj = self.objecthelper.create_mesh_object(n_block)
-
-            transform = nif_utils.import_matrix(n_block)  # set transform matrix for the mesh
-            self.mesh.import_mesh(n_block, b_obj, transform)
-
-            bpy.context.scene.objects.active = b_obj
-
-            # store flags etc
-            Object.import_object_flags(n_block, b_obj)
-            # skinning? add armature modifier
-            if n_block.skin_instance:
-                self.armaturehelper.append_armature_modifier(b_obj, b_armature)
-            return b_obj
+            return self.objecthelper.import_geometry_object(b_armature, n_block)
 
         elif isinstance(n_block, NifFormat.NiNode):
             # import object
@@ -245,7 +229,7 @@ class NifImport(NifCommon):
                 if NifOp.props.skeleton != "GEOMETRY_ONLY":
                     b_obj = self.armaturehelper.import_armature(n_block)
                 else:
-                    n_name = Object.import_name(n_block)
+                    n_name = block_store.import_name(n_block)
                     b_obj = armature.get_armature()
                     NifLog.info("Merging nif tree '{0}' with armature '{1}'".format(n_name, b_obj.name))
                     if n_name != b_obj.name:
@@ -255,7 +239,7 @@ class NifImport(NifCommon):
 
             elif self.armaturehelper.is_bone(n_block):
                 # bones have already been imported during import_armature
-                b_obj = b_armature.data.bones[Object.import_name(n_block)]
+                b_obj = b_armature.data.bones[block_store.import_name(n_block)]
                 # TODO [object] flags, shouldn't be treated any different than object flags.
                 b_obj.niftools.boneflags = n_block.flags
 
@@ -277,22 +261,7 @@ class NifImport(NifCommon):
 
                     geom_group = []
                 else:
-                    # node groups geometries, so import it as a mesh
-                    NifLog.info("Joining geometries {0} to single object '{1}'".format([child.name.decode() for child in geom_group], n_block.name.decode()))
-
-                    b_obj = self.objecthelper.create_mesh_object(n_block)
-                    b_obj.matrix_local = nif_utils.import_matrix(n_block)
-                    bpy.context.scene.objects.active = b_obj
-
-                    for child in geom_group:
-                        self.mesh.import_mesh(child, b_obj)
-
-                        # store flags etc
-                        Object.import_object_flags(child, b_obj)
-
-                    # is there skinning on any of the grouped geometries?
-                    if any(child.skin_instance for child in geom_group):
-                        self.armaturehelper.append_armature_modifier(b_obj, b_armature)
+                    b_obj = self.objecthelper.import_group_geometry(b_armature, geom_group, n_block)
 
             # find children that aren't part of the geometry group
             b_children = []


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
[Overview of the content of the pull request]
Remove the final parent refs from nif_import

##  Detailed Description
[List of functional updates]
- Restructured the Object class to resolve hierarchy issues; 
   - Object > Mesh > Object.
   - Nif_import > Material > Object, 
   - Move out long_name & import_name to block_registry, resolves cyclic dep.

-  Restructured the skin code from Armature
   - Moved out skin code to VertexGroup class
   - Moved out add modifier to object, as it is really an object function, also resolves cyclic dependency Object > Armature > Object

- Move Modifier code to object class

- Collision & Constraint
  - Relocated HAVOK_OBJECT dictionary which is used by both, collision & constraint, further sliming NifCommon
  - Move HAVOK_SCALE to collision class, though some re-ordering of actions, loading the files first so that we have values to be compared against. This needs rework in general as currently only looks at one game, probably should be a scene property or similar.
  - Remove the final parent passing/relative reference 😀

## Fixes Known Issues
[Ordered list of issues fixed by this PR]

## Documentation
[Overview of updates to documentation]
Covered by existing documentation

## Testing
[Overview of testing required to ensure functionality is correctly implemented]
Testing 

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

