### PR TITLE
Port/collision game radius

### DIFF
--- a/docs/user/features/collisions/collision_objects.rst
+++ b/docs/user/features/collisions/collision_objects.rst
@@ -3,26 +3,98 @@ Collision Object
 .. _collisionobject:
 
 
-.. warning::
+The following section deals with creating an object which will physically represent our collision object.
 
-   * This section has not been ported yet, meaning it does not currently work.
 
-The following section deals with creating a mesh-object which will physically represent our collision object.
-Once a suitable object has been created, then the appropriate settings should be enabled on 
+.. _collisionobject-mapping:
 
+Collision Object Mapping
+========================
+
+* The following section describes the most appropriate primitive object to represent the desired collision object type.
+* The suggested shapes are the same objects generated through import by the plugin.
+* Upon export, a collision object is created from data pulled from the Collision object.
+* Start by choosing a shape adequate to your model and follow the steps below the appropriate section.
+
+NiCollision
+~~~~~~~~~~~
+- Morrowind:
+
+The following type use the collision bound type and the name to decide what to map to
+
++----------------------------+-------------------+
+| Blender                    | Object Name       |
++============================+===================+
+| `Mesh Collision`_          | RootCollisionNode |
++----------------------------+-------------------+
+| `Bounding Box`_            | BSBound           |
++----------------------------+-------------------+
+| `Bounding Box`_            | BoundingBox       |
++----------------------------+-------------------+
+
+BhkShape
+~~~~~~~~
+- Oblivion, Fallout 3, and Fallout NV; 
+
++----------------------------+--------------------------------------------------------------+
+| Blender                    | Nif                                                          |
++============================+==============================================================+
+| `Box Collision`_           | :class:`~pyffi.formats.nif.NifFormat.bhkBoxShape`            |
++----------------------------+--------------------------------------------------------------+
+| `Sphere Collision`_        | :class:`~pyffi.formats.nif.NifFormat.bhkSphereShape`         |
++----------------------------+--------------------------------------------------------------+
+| `Capsule Collision`_       | :class:`~pyffi.formats.nif.NifFormat.bhkCapsuleShape`        |
++----------------------------+--------------------------------------------------------------+
+| `Convex Hull Collision`_   | :class:`~pyffi.formats.nif.NifFormat.bhkConvexVerticesShape` |
++----------------------------+--------------------------------------------------------------+
+| `Mesh Collision`_          | :class:`~pyffi.formats.nif.NifFormat.bhkMoppBvTreeShape`     |
++----------------------------+--------------------------------------------------------------+
 
 .. _collisionobject-bbox:
 
 Bounding Box
-============
+^^^^^^^^^^^^
 
 This is used as the bound box.
 
-#. Create a Mesh-Object to represent the bound box, a Cube is recommended.
+#. Create an Object of Mesh type to represent the bound box, a Cube is recommended.
 
-#. Name the object BSBound or BoundingBox, depending on which version you wish to be exported.
+#. Name the object BSBound or BoundingBox, depending on which version you need to be exported.
 
-#. In the Object Tab, enable bounds in the display section.
+#. :ref:`Refer to the Collision Settings to add physics to our collision object <collisonsettings>`.
+
+Visualisation
+
+#. In the Object Tab, under the **Viewport Display** section update the **Display As** to `BOUNDS`.
+#. Check the **Bounds** tickbox.
+#. Select `BOX` from the **shape** dropdown.
+
+
+Mesh Collision
+^^^^^^^^^^^^^^
+
+#. :ref:`Create your mesh-object <geometry-mesh>`.
+
+#. Create a convex hulled mesh-object. See :ref:`Notes<collision-convex-hull-notes>`
+
+#. Rename the polyhedron-mesh, eg. 'CollisionPolyhedron' via the Object panel.
+
+#. Scale the 'CollisionPoly' to the size wanted.
+
+#. :ref:`Refer to the Collision Settings to add physics to our collision object <collisonsettings>`.
+
+Visualisation
+
+#. In the Object Tab, under the **Viewport Display** section update the **Display As** to `BOUNDS`.
+#. Check the **Bounds** tickbox.
+#. Select `BOX` from the **shape** dropdown.
+
+.. _collision-mesh-notes:
+
+**Notes:**
+
+* Often a duplicate object can be used, simplified by decimating, then triangulated(**Ctrl + T**).
+* A :ref:`Convex Hulled Object<collision-convex-hull-notes>` can also be used.
 
 
 .. _collisionobject-havok:
@@ -44,43 +116,7 @@ This is used by the havok system for collision detection.
 Notes
 ~~~~~
 
-* Collision Bounds are represented by a dashed line, unlike Bounds which are by solid lines. 
-
-
-.. _collisionobject-havokobject:
-
-Collision Object
-~~~~~~~~~~~~~~~~
-
-* The following section describes the most appropriate primitive object to represent the desired collision object type.
-* The suggested shapes are the same objects generated through import by the plugin.
-* Upon export, a BhkShape is created from data pulled from the Collision object.
-* Start by choosing a shape adequate to your model and follow the steps below the appropriate section.
-
-
-- Oblivion, Fallout 3, and Fallout NV; 
-
-+----------------------------+--------------------------------------------------------------+
-| Blender                    | Nif                                                          |
-+============================+==============================================================+
-| `Box Collision`_           | :class:`~pyffi.formats.nif.NifFormat.bhkBoxShape`            |
-+----------------------------+--------------------------------------------------------------+
-| `Sphere Collision`_        | :class:`~pyffi.formats.nif.NifFormat.bhkSphereShape`         |
-+----------------------------+--------------------------------------------------------------+
-| `Capsule Collision`_       | :class:`~pyffi.formats.nif.NifFormat.bhkCapsuleShape`        |
-+----------------------------+--------------------------------------------------------------+
-| `Convex Hull Collision`_   | :class:`~pyffi.formats.nif.NifFormat.bhkConvexVerticesShape` |
-+----------------------------+--------------------------------------------------------------+
-| `Triangle Mesh Collision`_ | :class:`~pyffi.formats.nif.NifFormat.bhkMoppBvTreeShape`     |
-+----------------------------+--------------------------------------------------------------+
-
-- Morrowind:
-
-+----------------------------+-------------------+ 
-| Blender                    | Nif               |
-+============================+===================+
-| `Triangle Mesh Collision`_ | RootCollisionNode |
-+----------------------------+-------------------+
+* Collision Bounds are represented by a dashed line, unlike Bounds which are by solid lines.
 
 .. _collisionobject-havokbox:
 
@@ -164,44 +200,5 @@ Convex Hull Collision
 
 * It is advisable to use a convex hull generator to create the collision mesh.
 
-.. _collision-triangle-mesh:
-
-Triangle Mesh Collision
-^^^^^^^^^^^^^^^^^^^^^^^
-
-#. :ref:`Create your mesh-object <geometry-mesh>`.
-
-#. Create a convex hulled mesh-object. See :ref:`Notes<collision-convex-hull-notes>`
-
-#. Rename the polyhedron-mesh, eg. 'CollisionPolyhedron' via the Object panel.
-
-#. Scale the collision cube 'CollisionPoly' to the size wanted.
-
-#. :ref:`Add physics to our collision cube 'CollisionBox' <collisonsettings>`.
-
-.. _collision-triangle-mesh-notes:
-
-**Notes:**
-
-* Often a duplicate object can be used, simplified by decimating, then triangulated(**Ctrl + T**).
-* A :ref:`Convex Hulled Object<collision-convex-hull-notes>` can also be used.
-
-.. _collisionobject-rigidbody:
-
-Rigid Body
-~~~~~~~~~~
-
-.. small intro on what it is needed. Maybe not needed since it is just mass
-
-#. Go to the **Physics** tab in the **Properties** area.
-#. Click on **Rigid Body** to enable this modifier.
-
-   a) Set a mass adequate for your model.
-
-.. _collisionobject-collmodifier:
-
-Collision Modifier
-~~~~~~~~~~~~~~~~~~
-
-.. seems to be used in the code but no errors at export if not used - maybe not ported yet?
+.. _collision-mesh:
 

--- a/docs/user/features/collisions/collision_settings.rst
+++ b/docs/user/features/collisions/collision_settings.rst
@@ -3,51 +3,111 @@ Collision Settings
 .. _collisonsettings:
 
 The following section details the setting which need to be applied to the collision body to react appropriately in the collision simulation.
-A lot of these setting are havok specific; where possible we have mapped them to Blender's collision simulation.
-
+A lot of these setting are Havok specific; where possible we have mapped them to Blender's collision simulation.
 
 .. _collisonsettings-enable:
 
-Enabling Collisions
-===================
+Enabling Rigid Body Collisions
+==============================
 
-First, we enable Collision Setting for the selected Collision Object:
+First, we enable Rigid Body Collision for the selected collision Object:
 
-* In the **Physics** tab, enable **Collision Bounds** 
+* In the **Physics** tab, click on **Rigid Body** to enable.
 
-* Meshes with Collision Bounds enabled will be exported as a :class:`~pyffi.formats.nif.NifFormat.bhkShape`, rather than a :class:`~pyffi.formats.nif.NifFormat.NiTriShape`.
+* Meshes with collision enabled will be exported as a collision object rather than a :class:`~pyffi.formats.nif.NifFormat.NiTriShape`.
+
+#. Go to the **Physics** tab in the **Properties** area.
+#. Click on **Rigid Body** to enable this modifier.
+
+.. _collisionsettings-rigidbody:
+
+Rigid Body Panel
+==============================
+
+.. _collisionsettings-havok:
+
+The Rigid Body Panel is contains the properties to define how the object will react in the physics simulation.
+
+Settings Section
+~~~~~~~~~~~~~~~~
+
+In the **Setting** section
+
+    In the **mass** property is used to give the collision object a weight
 
 
-The bounds type is used to select which BhkShape type to use.
+Collision Section
+~~~~~~~~~~~~~~~~~
 
-* Select the desired **Bounds** type from the drop-down box.
+In the **collision** section
 
+    The **shape** property is used to map to various collision types, the following table shows what they will map to.
+    The following table uses a combination of the type & Blender object name to define the output type.
 
-.. _collisonsettings-havok:
++----------------------------+---------------------+-----------------------------------------------------------+
+| Blender                    | Blender Object Name | Nif                                                       |
++============================+=====================+===========================================================+
+| `Triangle Mesh Collision`_ | RootCollisionNode   | :class:`~pyffi.formats.nif.NifFormat.NiNode.bounding_box` |
++----------------------------+---------------------+-----------------------------------------------------------+
+| `Box Collision`_           | BSBound             | :class:`~pyffi.formats.nif.NifFormat.BSBound`             |
++----------------------------+---------------------+-----------------------------------------------------------+
+| `Box Collision`_           | BoundingBox         | :class:`~pyffi.formats.nif.NifFormat.NiNode`              |
++----------------------------+---------------------+-----------------------------------------------------------+
 
-Havok Settings
-==============
+- Oblivion, Fallout 3, and Fallout NV use bhk-based shapes
 
-* The Collision settings are used by the :class:`~pyffi.formats.nif.NifFormat.bhkShape` to control it reacts in the Havok physics simulation.
++----------------------------+--------------------------------------------------------------+
+| Blender                    | Nif                                                          |
++============================+==============================================================+
+| `Box Collision`_           | :class:`~pyffi.formats.nif.NifFormat.bhkBoxShape`            |
++----------------------------+--------------------------------------------------------------+
+| `Sphere Collision`_        | :class:`~pyffi.formats.nif.NifFormat.bhkSphereShape`         |
++----------------------------+--------------------------------------------------------------+
+| `Capsule Collision`_       | :class:`~pyffi.formats.nif.NifFormat.bhkCapsuleShape`        |
++----------------------------+--------------------------------------------------------------+
+| `Convex Hull Collision`_   | :class:`~pyffi.formats.nif.NifFormat.bhkConvexVerticesShape` |
++----------------------------+--------------------------------------------------------------+
+| `Triangle Mesh Collision`_ | :class:`~pyffi.formats.nif.NifFormat.bhkMoppBvTreeShape`     |
++----------------------------+--------------------------------------------------------------+
 
-.. 
-   todo::
+Surface Response Section
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-   Probably a better way to display the information too, perhaps a table with the setting -> detail?. Could bloat though.
-   Decide if we should reference the nif.xml directly or improve tooltips?
+In the **Surface Response** section the following are mapped to nif properties
 
+- friction :  How smooth its surfaces is and how easily it will slide along other bodies
 
-   The **Radius** is used as the region around the collision object.
-   If another collision object intersects this region; a quicker, but less accurate collision algorithm is used. 
-   If the object intersects further than the region value, then full collision calculation occurs.
-   
-   * Set the **Radius** to the appropriate number.
-   
+- restitution : How "bouncy" the body is, i.e. how much energy it has after colliding. Less than 1.0 loses energy, greater than 1.0 gains energy.
+
+Sensitivity Section
+~~~~~~~~~~~~~~~~~~~
+
+In the **Surface Response** section, enable the collsion margin.
+
+- margin : This is an area around the mesh that allows for quick but less accurate collision detection.
+
+Dynamics Section
+~~~~~~~~~~~~~~~~~~~
+
+In the **Surface Response** section, the following are mapped to nif properties
+
+- linear_damping : Reduces the movement of the body over time. A value of 0.1 will remove 10% of the linear velocity every second.
+
+- angular_damping : Reduces the movement of the body over time. A value of 0.05 will remove 5% of the angular velocity every second.
+
+Enable the **Deactivation** checkbox to access the following settings
+
+- Deactivate Linear velocity : Linear velocity
+- Deactivate Angular Velocity : Angular velocity
+
+Custom Niftools Settings
+========================
+
+The following describe custom Nif specific settings that don't map directly to Blender settings currently;
+
    The **Havok Material** decides how the material should behave for collisions, eg. sound, decals.
-   
+
    * Select a **Havok Material** from the drop-down box.
-   
-                     Velocity Max does not seem to be used in the nif.
    
    The **Collision Filter Flags** determines
    
@@ -80,16 +140,3 @@ Havok Settings
    The **Motion System** determines.
    
    * Select a **Motion System** from the drop-down box.
-   
-   The **LHMaxFriction** determines .
-   
-   * Set the **LHMaxFriction** to the appropriate number.
-   
-   The **tau** determines.
-   
-   * Set the **tau** to the appropriate number.
-   
-   The **Damping** determines.
-   
-   * Set the **Damping** to the appropriate number.
-

--- a/io_scene_nif/modules/nif_export/collision/havok.py
+++ b/io_scene_nif/modules/nif_export/collision/havok.py
@@ -362,7 +362,7 @@ class BhkCollision(Collision):
                                       (box_extends[2][0] + box_extends[2][1]) / 2.0))
 
             # and transform it to global coordinates
-            center = center * hktf
+            center = center @ hktf
             hktf[0][3] = center[0]
             hktf[1][3] = center[1]
             hktf[2][3] = center[2]

--- a/io_scene_nif/modules/nif_import/collision/__init__.py
+++ b/io_scene_nif/modules/nif_import/collision/__init__.py
@@ -74,6 +74,7 @@ class Collision:
         """ Helper function to set up b_obj so it becomes recognizable as a collision object """
         # set bounds type
         b_obj.display_type = 'BOUNDS'
+        b_obj.show_bounds = True
         b_obj.display_bounds_type = bounds_type
 
         override = bpy.context.copy()

--- a/io_scene_nif/modules/nif_import/collision/__init__.py
+++ b/io_scene_nif/modules/nif_import/collision/__init__.py
@@ -75,9 +75,17 @@ class Collision:
         # set bounds type
         b_obj.display_type = 'BOUNDS'
         b_obj.display_bounds_type = bounds_type
-        # b_obj.game.use_collision_bounds = True
-        # b_obj.game.collision_bounds_type = bounds_type
-        # b_obj.game.radius = radius
+
+        override = bpy.context.copy()
+        override['selected_objects'] = b_obj
+        bpy.ops.rigidbody.object_add(override)
+
+        b_r_body = b_obj.rigid_body
+        b_r_body.enabled = True
+        b_r_body.use_margin = True
+        b_r_body.collision_margin = radius
+        b_r_body.collision_shape = bounds_type
+
         b_me = b_obj.data
         if n_obj:
             # todo [pyffi] nif xml 0.7.1.1 HavokMaterial is a union of 3 enums under the HavokMaterial.material field, probably broken!

--- a/io_scene_nif/modules/nif_import/collision/havok.py
+++ b/io_scene_nif/modules/nif_import/collision/havok.py
@@ -169,13 +169,6 @@ class BhkCollision(Collision):
                 # (mass 0 results in issues with simulation)
                 b_r_body.mass = bhkshape.mass / len(collision_objs)
 
-            b_col_obj.nifcollision.deactivator_type = NifFormat.DeactivatorType._enumkeys[bhkshape.deactivator_type]
-            b_col_obj.nifcollision.solver_deactivation = NifFormat.SolverDeactivation._enumkeys[
-                bhkshape.solver_deactivation]
-            # b_col_obj.nifcollision.oblivion_layer = NifFormat.OblivionLayer._enumkeys[bhkshape.layer]
-            # b_col_obj.nifcollision.quality_type = NifFormat.MotionQuality._enumkeys[bhkshape.quality_type]
-            # b_col_obj.nifcollision.motion_system = NifFormat.MotionSystem._enumkeys[bhkshape.motion_system]
-
             b_r_body.mass = bhkshape.mass / len(collision_objs)
 
             b_r_body.use_deactivation = True
@@ -186,15 +179,20 @@ class BhkCollision(Collision):
             vel = bhkshape.linear_velocity
             b_r_body.deactivate_linear_velocity = mathutils.Vector([vel.w, vel.x, vel.y, vel.z]).magnitude
             ang_vel = bhkshape.angular_velocity
-            b_r_body.deactivate_angular_velocity = mathutils.Vector(
-                [ang_vel.w, ang_vel.x, ang_vel.y, ang_vel.z]).magnitude
+            b_r_body.deactivate_angular_velocity = mathutils.Vector([ang_vel.w, ang_vel.x, ang_vel.y, ang_vel.z]).magnitude
 
+            # Custom Niftools properties
             b_col_obj.collision.permeability = bhkshape.penetration_depth
-
+            b_col_obj.nifcollision.deactivator_type = NifFormat.DeactivatorType._enumkeys[bhkshape.deactivator_type]
+            b_col_obj.nifcollision.solver_deactivation = NifFormat.SolverDeactivation._enumkeys[bhkshape.solver_deactivation]
             b_col_obj.nifcollision.max_linear_velocity = bhkshape.max_linear_velocity
             b_col_obj.nifcollision.max_angular_velocity = bhkshape.max_angular_velocity
 
+            # b_col_obj.nifcollision.oblivion_layer = NifFormat.OblivionLayer._enumkeys[bhkshape.layer]
+            # b_col_obj.nifcollision.quality_type = NifFormat.MotionQuality._enumkeys[bhkshape.quality_type]
+            # b_col_obj.nifcollision.motion_system = NifFormat.MotionSystem._enumkeys[bhkshape.motion_system]
             # b_col_obj.nifcollision.col_filter = bhkshape.col_filter
+
         # import constraints
         # this is done once all objects are imported for now, store all imported havok shapes with object lists
         collision.DICT_HAVOK_OBJECTS[bhkshape] = collision_objs
@@ -263,8 +261,7 @@ class BhkCollision(Collision):
 
         b_obj = Object.mesh_from_data("convexpoly", verts, faces)
         radius = bhk_shape.radius * self.HAVOK_SCALE
-        self.set_b_collider(b_obj, "BOX", radius, bhk_shape)
-        # b_obj.rigid_body.collision_shape = 'CONVEX_HULL'
+        self.set_b_collider(b_obj, "CONVEX_HULL", radius, bhk_shape)
         return [b_obj]
 
     def import_bhkpackednitristrips_shape(self, bhk_shape):
@@ -300,8 +297,7 @@ class BhkCollision(Collision):
 
             b_obj = Object.mesh_from_data('poly%i' % subshape_num, verts, faces)
             radius = min(vert.co.length for vert in b_obj.data.vertices)
-            self.set_b_collider(b_obj, "BOX", radius, subshape)
-            # b_obj.rigid_body.collision_shape = 'TRIANGLE_MESH'
+            self.set_b_collider(b_obj, "MESH", radius, subshape)
 
             vertex_offset += subshape.num_vertices
             hk_objects.append(b_obj)
@@ -315,6 +311,5 @@ class BhkCollision(Collision):
         faces = list(bhk_shape.get_triangles())
         b_obj = Object.mesh_from_data("poly", verts, faces)
         # TODO [collision] self.havok_mat!
-        self.set_b_collider(b_obj, "BOX", bhk_shape.radius)
-        # b_obj.rigid_body.collision_shape = 'TRIANGLE_MESH'
+        self.set_b_collider(b_obj, "MESH", bhk_shape.radius)
         return [b_obj]

--- a/io_scene_nif/ui/collision.py
+++ b/io_scene_nif/ui/collision.py
@@ -1,4 +1,4 @@
-"""Nif User Interface, connect custom properties from properties.py into Blenders UI"""
+"""Nif User Interface, connect custom collision properties from properties.py into Blenders UI"""
 
 # ***** BEGIN LICENSE BLOCK *****
 # 
@@ -47,44 +47,25 @@ class CollisionBoundsPanel(Panel):
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
     bl_context = "physics"
-    '''
-    @classmethod
-    def poll(cls, context):
-    '''
 
     def draw_header(self, context):
-        pass
-        #  todo [collision/ui] we use removed game engine properties here - can we use standard blender properties or do we need custom ones?
-        # game = context.active_object.game
-        # col_setting = context.active_object.nifcollision
-        # self.layout.prop(col_setting, "use_collision_bounds", text="")
+        if context.active_object.rigid_body:
+            return True
+        return False
 
     def draw(self, context):
         layout = self.layout
 
-        # game = context.active_object.game
         col_setting = context.active_object.nifcollision
 
-        # todo [collision/ui] we use removed game engine properties here - can we use standard blender properties or do we need custom ones?
-        # layout.active = col_setting.use_collision_bounds
-        # layout.prop(game, "collision_bounds_type", text="Bounds Type")
-        # layout.prop(game, "radius", text="Radius")
-        # layout.prop(game, "velocity_max", text="Velocity Max")
-
         box = layout.box()
-        # box.active = game.use_collision_bounds
-
         box.prop(col_setting, "col_filter", text='Col Filter')  # col filter prop
-        box.prop(col_setting, "deactivator_type", text='Deactivator Type')  # motion dactivation prop
-        box.prop(col_setting, "solver_deactivation", text='Solver Deactivator')  # motion dactivation prop
+        box.prop(col_setting, "deactivator_type", text='Deactivator Type')  # motion deactivation prop
+        box.prop(col_setting, "solver_deactivation", text='Solver Deactivator')  # motion deactivation prop
         box.prop(col_setting, "quality_type", text='Quality Type')  # quality type prop
         box.prop(col_setting, "oblivion_layer", text='Oblivion Layer')  # oblivion layer prop
         box.prop(col_setting, "max_linear_velocity", text='Max Linear Velocity')  # oblivion layer prop
         box.prop(col_setting, "max_angular_velocity", text='Max Angular Velocity')  # oblivion layer prop
         box.prop(col_setting, "motion_system", text='Motion System')  # motion system prop
 
-        con_setting = context.active_object.niftools_constraint
 
-        box.prop(con_setting, "LHMaxFriction", text='LHMaxFriction')
-        box.prop(con_setting, "tau", text='tau')
-        box.prop(con_setting, "damping", text='Damping')


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
[Overview of the content of the pull request]
Port the collision system to the new Blender 2.8 api

##  Detailed Description
[List of functional updates]
- Finish off porting the remaining collision setting to the Blender 2.8 api due to the removal of the Blender game engine.
- Fix issues with export that were still referring to old game api.
- Remove custom NIF constraint setting from Collision Panel
- Only show the Niftools Collision Panel when the is collision enabled on the object.

## Fixes Known Issues
[Ordered list of issues fixed by this PR]

## Documentation
[Overview of updates to documentation]
Overhaul the documentation for collision support to reflect the new UI.

## Testing
[Overview of testing required to ensure functionality is correctly implemented]

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

