### PR TITLE
Merge/bs effect shader missing texture fix

### DIFF
--- a/io_scene_nif/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_nif/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -62,8 +62,11 @@ class BSShaderTexture(TextureSlotManager):
 
     def export_bs_effect_shader_prop_textures(self, bsshader):
         bsshader.texture_set = self._create_textureset()
-        bsshader.source_texture = TextureWriter.export_texture_filename(self.b_diffuse_slot.texture)
-        bsshader.greyscale_texture = TextureWriter.export_texture_filename(self.b_glow_slot.texture)
+
+        if self.b_diffuse_slot:
+            bsshader.source_texture = TextureWriter.export_texture_filename(self.b_diffuse_slot.texture)
+        if self.b_glow_slot:
+            bsshader.greyscale_texture = TextureWriter.export_texture_filename(self.b_glow_slot.texture)
 
         # clamp Mode
         bsshader.texture_clamp_mode = 65283

--- a/io_scene_nif/modules/nif_import/property/texture/types/bsshadertexture.py
+++ b/io_scene_nif/modules/nif_import/property/texture/types/bsshadertexture.py
@@ -85,7 +85,10 @@ class BSShaderTexture:
 
     def import_bseffectshaderproperty_textures(self, bs_effect_shader_property, nodes_wrapper):
 
-        nodes_wrapper.create_and_link("Base", bs_effect_shader_property.source_texture.decode())
+        base = bs_effect_shader_property.source_texture.decode()
+        if base:
+            nodes_wrapper.create_and_link("Base", base)
+
         glow = bs_effect_shader_property.greyscale_texture.decode()
         if glow:
             nodes_wrapper.create_and_link("Glow", glow)


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Import now sets the (Blender) glow slot texture from the greyscale texture 

##  Detailed Description

The glow slow was set to the source texture upon import, whereas the export set the greyscale texture from the glow slot. This meant that upon import > export of a vanilla nif, the greyscale texture was set to the same as the source texture. Import now sets the glow slot from the greyscale texture.
A missing source texture or greyscale (like found in some vanilla BSEffectShaders) led to error upon export  back to nif. Fixed by adding a check for the slot existing.

## Fixes Known Issues
This should this fix two problems I have seen with the import/export of BSEffectShaderProperties.
1. Closes #343  
2. Closes #344 

## Documentation
[Overview of updates to documentation]

## Testing
[Overview of testing required to ensure functionality is correctly implemented]

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

