### PR TITLE
Automatically select suitable axis orientation

### DIFF
--- a/io_scene_nif/modules/nif_export/object/__init__.py
+++ b/io_scene_nif/modules/nif_export/object/__init__.py
@@ -263,17 +263,8 @@ class Object:
 
     def export_collision(self, b_obj, n_parent):
         """Main function for adding collision object b_obj to a node."""
-        if bpy.context.scene.niftools_scene.game == 'MORROWIND':
-            if b_obj.game.collision_bounds_type != 'TRIANGLE_MESH':
-                raise util_math.NifError("Morrowind only supports Triangle Mesh collisions.")
-            node = block_store.create_block("RootCollisionNode", b_obj)
-            n_parent.add_child(node)
-            node.flags = 0x0003  # default
-            util_math.set_object_matrix(b_obj, node)
-            for child in b_obj.children:
-                self.export_node(child, node, None)
 
-        elif bpy.context.scene.niftools_scene.game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM'):
+        if bpy.context.scene.niftools_scene.game in ('OBLIVION', 'FALLOUT_3', 'SKYRIM'):
 
             nodes = [n_parent]
             nodes.extend([block for block in n_parent.children if block.name[:14] == 'collisiondummy'])

--- a/io_scene_nif/modules/nif_export/property/object/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/object/__init__.py
@@ -70,35 +70,35 @@ class ObjectProperty:
                          ):
                 n_block.add_property(prop)
 
-        # todo [property] refactor this
-        # add textures
-        if bpy.context.scene.niftools_scene.game == 'FALLOUT_3':
-            bsshader = self.bss_helper.export_bs_shader_property(b_mat)
+            # todo [property] refactor this
+            # add textures
+            if bpy.context.scene.niftools_scene.game == 'FALLOUT_3':
+                bsshader = self.bss_helper.export_bs_shader_property(b_mat)
 
-            block_store.register_block(bsshader)
-            n_block.add_property(bsshader)
-        elif bpy.context.scene.niftools_scene.game == 'SKYRIM':
-            bsshader = self.bss_helper.export_bs_shader_property(b_mat)
+                block_store.register_block(bsshader)
+                n_block.add_property(bsshader)
+            elif bpy.context.scene.niftools_scene.game == 'SKYRIM':
+                bsshader = self.bss_helper.export_bs_shader_property(b_mat)
 
-            block_store.register_block(bsshader)
-            num_props = n_block.num_properties
-            n_block.num_properties = num_props + 1
-            n_block.bs_properties.update_size()
-            n_block.bs_properties[num_props] = bsshader
+                block_store.register_block(bsshader)
+                num_props = n_block.num_properties
+                n_block.num_properties = num_props + 1
+                n_block.bs_properties.update_size()
+                n_block.bs_properties[num_props] = bsshader
 
-        else:
-            if bpy.context.scene.niftools_scene.game in self.texture_helper.USED_EXTRA_SHADER_TEXTURES:
-                # sid meier's railroad and civ4: set shader slots in extra data
-                self.texture_helper.add_shader_integer_extra_datas(n_block)
+            else:
+                if bpy.context.scene.niftools_scene.game in self.texture_helper.USED_EXTRA_SHADER_TEXTURES:
+                    # sid meier's railroad and civ4: set shader slots in extra data
+                    self.texture_helper.add_shader_integer_extra_datas(n_block)
 
-            n_nitextureprop = self.texture_helper.export_texturing_property(
-                flags=0x0001,  # standard
-                # TODO [object][texture][material] Move out and break dependency
-                applymode=self.texture_helper.get_n_apply_mode_from_b_blend_type('MIX'),
-                b_mat=b_mat)
+                n_nitextureprop = self.texture_helper.export_texturing_property(
+                    flags=0x0001,  # standard
+                    # TODO [object][texture][material] Move out and break dependency
+                    applymode=self.texture_helper.get_n_apply_mode_from_b_blend_type('MIX'),
+                    b_mat=b_mat)
 
-            block_store.register_block(n_nitextureprop)
-            n_block.add_property(n_nitextureprop)
+                block_store.register_block(n_nitextureprop)
+                n_block.add_property(n_nitextureprop)
 
     def get_matching_block(self, block_type, **kwargs):
         """Try to find a block matching block_type. Keyword arguments are a dict of parameters and required attributes of the block"""

--- a/io_scene_nif/modules/nif_import/object/__init__.py
+++ b/io_scene_nif/modules/nif_import/object/__init__.py
@@ -95,19 +95,6 @@ class Object:
         faces = [[0, 1, 3, 2], [6, 7, 5, 4], [0, 2, 6, 4], [3, 1, 5, 7], [4, 5, 1, 0], [7, 6, 2, 3]]
         return Object.mesh_from_data(b_name, verts, faces)
 
-    def import_root_collision(self, n_node, b_obj):
-        """ Import a RootCollisionNode """
-        if isinstance(n_node, NifFormat.RootCollisionNode):
-            b_obj.display_type = 'BOUNDS'
-            b_obj.show_wire = True
-            b_obj.display_bounds_type = 'BOX'
-            # b_obj.game.use_collision_bounds = True
-            # b_obj.game.collision_bounds_type = 'TRIANGLE_MESH'
-            b_obj.niftools.flags = n_node.flags
-            b_mesh = b_obj.data
-            b_mesh.validate()
-            b_mesh.update()
-
     def set_object_bind(self, b_obj, b_obj_children, b_armature):
         """ Sets up parent-child relationships for b_obj and all its children and corrects space for children of bones"""
         if isinstance(b_obj, bpy.types.Object):

--- a/io_scene_nif/modules/nif_import/object/types.py
+++ b/io_scene_nif/modules/nif_import/object/types.py
@@ -49,6 +49,7 @@ class NiTypes:
     def import_root_collision(n_node, b_obj):
         """ Import a RootCollisionNode """
         if isinstance(n_node, NifFormat.RootCollisionNode):
+            b_obj["type"] = "RootCollisionNode"
             b_obj.name = "RootCollisionNode"
             b_obj.display_type = 'BOUNDS'
             b_obj.show_wire = True

--- a/io_scene_nif/modules/nif_import/object/types.py
+++ b/io_scene_nif/modules/nif_import/object/types.py
@@ -46,6 +46,18 @@ from io_scene_nif.modules.nif_import.object import Object
 class NiTypes:
 
     @staticmethod
+    def import_root_collision(n_node, b_obj):
+        """ Import a RootCollisionNode """
+        if isinstance(n_node, NifFormat.RootCollisionNode):
+            b_obj.name = "RootCollisionNode"
+            b_obj.display_type = 'BOUNDS'
+            b_obj.show_wire = True
+            b_obj.display_bounds_type = 'BOX'
+            # b_obj.game.use_collision_bounds = True
+            # b_obj.game.collision_bounds_type = 'TRIANGLE_MESH'
+            b_obj.niftools.flags = n_node.flags
+
+    @staticmethod
     def import_range_lod_data(n_node, b_obj, b_children):
         """ Import LOD ranges and mark b_obj as a LOD node """
         if isinstance(n_node, NifFormat.NiLODNode):

--- a/io_scene_nif/modules/nif_import/property/geometry/mesh.py
+++ b/io_scene_nif/modules/nif_import/property/geometry/mesh.py
@@ -69,6 +69,9 @@ class MeshPropertyProcessor:
         b_mesh = b_obj.data
         # get all valid properties that are attached to n_block
         props = list(prop for prop in itertools.chain(n_block.properties, n_block.bs_properties) if prop is not None)
+        # we need no material if we have no properties
+        if not props:
+            return
         # just to avoid duped materials, a first pass, make sure a named material is created or retrieved
         for prop in props:
             if prop.name:

--- a/io_scene_nif/modules/nif_import/property/texture/loader.py
+++ b/io_scene_nif/modules/nif_import/property/texture/loader.py
@@ -106,9 +106,6 @@ class TextureLoader:
         return fn, tex
 
     def import_external_source(self, source):
-        b_image = None
-        fn = None
-
         # the texture uses an external image file
         if isinstance(source, NifFormat.NiSourceTexture):
             fn = source.file_name.decode()

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -258,7 +258,7 @@ class NifImport(NifCommon):
             self.objecthelper.set_object_bind(b_obj, b_children, b_armature)
 
             # import extra node data, such as node type
-            self.objecthelper.import_root_collision(n_block, b_obj)
+            NiTypes.import_root_collision(n_block, b_obj)
             NiTypes.import_billboard(n_block, b_obj)
             NiTypes.import_range_lod_data(n_block, b_obj, b_children)
 

--- a/io_scene_nif/nif_import.py
+++ b/io_scene_nif/nif_import.py
@@ -91,9 +91,6 @@ class NifImport(NifCommon):
                 if len(self.SELECTED_OBJECTS) != 1 or self.SELECTED_OBJECTS[0].type != 'ARMATURE':
                     raise util_math.NifError("You must select exactly one armature in 'Import Geometry Only' mode.")
 
-            # the axes used for bone correction depend on the nif version
-            util_math.set_bone_orientation(NifOp.props.axis_forward, NifOp.props.axis_up)
-
             NifLog.info("Importing data")
             # calculate and set frames per second
             if NifOp.props.animation:

--- a/io_scene_nif/operators/nif_import_op.py
+++ b/io_scene_nif/operators/nif_import_op.py
@@ -39,14 +39,12 @@
 
 import bpy
 from bpy.types import Operator
-from bpy_extras.io_utils import ImportHelper, orientation_helper
+from bpy_extras.io_utils import ImportHelper
 
 from io_scene_nif import nif_import
 from .nif_common_op import NifOperatorCommon
 
 
-# todo [version/armature] detect or overwrite these
-@orientation_helper(axis_forward='X', axis_up='Y')
 class NifImportOperator(Operator, ImportHelper, NifOperatorCommon):
     """Operator for loading a nif file."""
 


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
[Overview of the content of the pull request]
Import now aligns armatures without user input

##  Detailed Description
- removes forward and up selector from nif import op so users no longer need to decide which option to select
- adds a robust orientation heuristic to armature import
- Fix issue with root collision import
- Remove unnecessary material creation.

## Fixes Known Issues
[Ordered list of issues fixed by this PR]
Closes #354 ReferenceError: StructRNA of type Image has been removed

## Documentation
[Overview of updates to documentation]

## Testing
[Overview of testing required to ensure functionality is correctly implemented]

### Manual
[Order steps to manually verify updates are working correctly]
both skyrim (Z forward) and previous games (X forward) import with nicely aligned bones

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

