### PR TITLE
Fix windows build system

### DIFF
--- a/install/install.bat
+++ b/install/install.bat
@@ -2,15 +2,15 @@
 
 :: Script to install the blender nif scripts
 
-set DIR=%~dps0
+set "DIR=%~dps0"
 :: remove trailing backslash
-if "%DIR:~-1%" == "\" set DIR="%DIR:~0,-1%"
-set ROOT="%DIR%\.."
-set NAME=blender_nif_plugin
-set /p VERSION=<%ROOT%\io_scene_nif\VERSION
+if "%DIR:~-1%" == "\" set "DIR=%DIR:~0,-1%"
+for %%I in ("%DIR%\..") do set "ROOT=%%~fI"
+set "NAME=blender_nif_plugin"
+set /p VERSION=<%ROOT%\io_scene_nif\VERSION.txt
 for /f %%i in ('git rev-parse --short HEAD') do set HASH=%%i
-for /f %%i in ('date +%F') do set DATE=%%i
-set ZIP_NAME="%NAME%-%VERSION%-%DATE%-%HASH%"
+for /f %%i in ('echo %date%') do set DATE=%%i
+set "ZIP_NAME=%NAME%-%VERSION%-%DATE%-%HASH%"
 
 if "%BLENDER_ADDONS_DIR%" == "" if not exist "%BLENDER_ADDONS_DIR%" (
 echo. "Update BLENDER_ADDONS_DIR to the folder where the blender addons reside, such as:"

--- a/install/makezip.bat
+++ b/install/makezip.bat
@@ -1,18 +1,18 @@
 @echo off
 
-set DIR=%~dps0
+set "DIR=%~dps0"
 :: remove trailing backslash
 if "%DIR:~-1%" == "\" (
-    set DIR="%DIR:~0,-1%"
+    set "DIR=%DIR:~0,-1%"
 )
 
-set ROOT="%DIR%"\..
-set NAME="blender_nif_plugin"
-set /p VERSION="%ROOT%\io_scene_nif\VERSION.txt"
+for %%I in ("%DIR%\..") do set "ROOT=%%~fI"
+set "NAME=blender_nif_plugin"
+set /p VERSION=<%ROOT%\io_scene_nif\VERSION.txt
 :: Abuse for loop to execute and store command output
 for /f %%i in ('git rev-parse --short HEAD') do set HASH=%%i
-for /f %%i in ('date +%F') do set DATE=%%i
-set ZIP_NAME="%NAME%-%VERSION%-%DATE%-%HASH%"
+for /f %%i in ('echo %date%') do set DATE=%%i
+set "ZIP_NAME=%NAME%-%VERSION%-%DATE%-%HASH%"
 set PYFFI_VERSION="2.2.4.dev3"
 set DEPS="io_scene_nif\dependencies"
 if exist "%DIR%\temp" rmdir /s /q "%DIR%\temp"
@@ -21,7 +21,7 @@ mkdir "%DIR%"\temp
 
 pushd "%DIR%"\temp
 mkdir io_scene_nif
-xcopy /s "%ROOT%"\io_scene_nif io_scene_nif
+xcopy /s "%ROOT%\io_scene_nif" io_scene_nif
 mkdir "%DEPS%"
 
 python -m pip install "PyFFI==%PYFFI_VERSION%" --target="%DEPS%"

--- a/testframework/install_deps.bat
+++ b/testframework/install_deps.bat
@@ -12,7 +12,9 @@ goto end
 ::TODO replace with equivalent setup.py call via pip to remove
 
 echo. "Installing Sphinx to %BLENDER_ADDONS_DIR%"
-python -m pip install "Sphinx nose" --target="%BLENDER_ADDONS_DIR%"
+python -m pip install "Sphinx" --target="%BLENDER_ADDONS_DIR%"
+echo. "Installing nose to %BLENDER_ADDONS_DIR%"
+python -m pip install "nose" --target="%BLENDER_ADDONS_DIR%"
 echo. "Installing pydevd debugger"
 python -m pip install "pydevd-pycharm~=201.6668.60" --target="%BLENDER_ADDONS_DIR%"
 


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Issues with install_deps.bat, install.bat and makezip.bat were fixed that led to errors. Same fixes as to the develop branch.

##  Detailed Description
*Separated out the sphinx/nose installation to two separate pip commands.
*Fixed quotation marks position in install.bat and makezip.bat which previously lead to quotation marks being included in the variable values.
*Fixed parent folder getting, which previously just appended \.. to the file path (doesn't work). Needed to use for loop, since getting the path from it uses substitution of FOR variable references.
*Fixed date getting syntax error. Date getting used %F (Unix), which is not a valid option in windows and led to syntax errors. However, the current solution does mean that the date format will be dependent on the user's date/time settings.

## Fixes Known Issues
Issues not known beforehand.

## Documentation
None

## Testing
Running install_deps.bat and install.bat (which runs makezip.bat) previously led to errors and would not install the plugin into Blender. Running install.bat should now result in the plugin being installed, and therefore correct import/export of nifs.

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]
