### PR TITLE
Fixes to BSLightingShaderProperty

### DIFF
--- a/io_scene_nif/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/shader/__init__.py
@@ -95,7 +95,7 @@ class BSShaderProperty:
     def export_bs_lighting_shader_property(self, b_mat):
         bsshader = NifFormat.BSLightingShaderProperty()
         b_s_type = NifFormat.BSLightingShaderPropertyShaderType._enumkeys.index(b_mat.niftools_shader.bslsp_shaderobjtype)
-        bsshader.shader_type = NifFormat.BSLightingShaderPropertyShaderType._enumvalues[b_s_type]
+        bsshader.skyrim_shader_type = NifFormat.BSLightingShaderPropertyShaderType._enumvalues[b_s_type]
 
         self.texturehelper.export_bs_lighting_shader_prop_textures(bsshader)
 

--- a/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
@@ -139,6 +139,11 @@ class BSShaderPropertyProcessor(BSShader):
         # if n_alpha_prop:
         #     self.b_mat = self.set_alpha_bsshader(self.b_mat, bs_shader_property)
 
+        # Emissive color
+        Material.import_material_emissive(self.b_mat, bs_shader_property.emissive_color)
+        # todo [shader] create custom float property, or use as factor in mix shader?
+        # self.b_mat.emit = bs_shader_property.emissive_multiple
+
         # gloss
         Material.import_material_gloss(self.b_mat, bs_shader_property.glossiness)
 

--- a/io_scene_nif/properties/shader.py
+++ b/io_scene_nif/properties/shader.py
@@ -229,8 +229,8 @@ class ShaderProps(PropertyGroup):
         name='Use Falloff'
     )
 
-    slsf_1_enviroment_mapping: BoolProperty(
-        name='Enviroment Mapping'
+    slsf_1_environment_mapping: BoolProperty(
+        name='Environment Mapping'
     )
 
     slsf_1_recieve_shadows: BoolProperty(

--- a/io_scene_nif/ui/shader.py
+++ b/io_scene_nif/ui/shader.py
@@ -104,7 +104,7 @@ class ShaderPanel(Panel):
             row.prop(nif_obj_props, "slsf_1_cast_shadows")
             row.prop(nif_obj_props, "slsf_1_decal")
             row.prop(nif_obj_props, "slsf_1_dynamic_decal")
-            row.prop(nif_obj_props, "slsf_1_enviroment_mapping")
+            row.prop(nif_obj_props, "slsf_1_environment_mapping")
             row.prop(nif_obj_props, "slsf_1_external_emittance")
             row.prop(nif_obj_props, "slsf_1_eye_environment_mapping")
             row.prop(nif_obj_props, "slsf_1_facegen_detail")


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Fixes to BSLightingShaderProperty environment mapping flag import/export, shader type export and emissive color import.

##  Detailed Description
* Fixed the spelling of the environment map flag in the UI. The misspelling meant that the flag was not set upon import, and even when setting the flag upon export, it would not be reflected in the exported nif.
* Fixed the BSLightingShaderProperty Skyrim Shader Type export setting. The current code set the wrong property, meaning that it would always export to Default (instead of, for example, Environment Map or Glow Shader).
* Brought the BSLightingShaderProperty emissive color import in line with how the BSEffectShaderProperty imported it, as well as with how it is exported, meaning that import and subsequent export will give the same emissive color as in the original nif.

## Fixes Known Issues
Issues were not known beforehand

## Documentation
[Overview of updates to documentation]

## Testing

### Manual
[Order steps to manually verify updates are working correctly]
Import this mesh: 

[irondaggerEmissiveTest.nif.zip](https://github.com/niftools/blender_nif_plugin/files/4673782/irondaggerEmissiveTest.nif.zip)
Upon import under the IronDagger01:0 object material's tab, within 
- the NifTools material Color Panel, 
- the Environment Mapping flag should be set,
- the emissive color should be red.

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

