### PR TITLE
Fixes to BSLightingShaderProperty and porting of develop branch code

### DIFF
--- a/io_scene_nif/modules/nif_export/collision/havok.py
+++ b/io_scene_nif/modules/nif_export/collision/havok.py
@@ -152,13 +152,13 @@ class BhkCollision(Collision):
         n_r_body.layer_copy = n_r_body.layer
         n_r_body.col_filter_copy = n_r_body.col_filter
         # TODO [format] nif.xml update required
-        ukn_6 = n_r_body.unknown_6_shorts
-        ukn_6[0] = 21280
-        ukn_6[1] = 4581
-        ukn_6[2] = 62977
-        ukn_6[3] = 65535
-        ukn_6[4] = 44
-        ukn_6[5] = 0
+        # ukn_6 = n_r_body.unknown_6_shorts
+        # ukn_6[0] = 21280
+        # ukn_6[1] = 4581
+        # ukn_6[2] = 62977
+        # ukn_6[3] = 65535
+        # ukn_6[4] = 44
+        # ukn_6[5] = 0
 
         b_r_body = b_obj.rigid_body
         # mass is 1.0 at the moment (unless property was set on import or by the user)

--- a/io_scene_nif/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/shader/__init__.py
@@ -95,7 +95,7 @@ class BSShaderProperty:
     def export_bs_lighting_shader_property(self, b_mat):
         bsshader = NifFormat.BSLightingShaderProperty()
         b_s_type = NifFormat.BSLightingShaderPropertyShaderType._enumkeys.index(b_mat.niftools_shader.bslsp_shaderobjtype)
-        bsshader.shader_type = NifFormat.BSLightingShaderPropertyShaderType._enumvalues[b_s_type]
+        bsshader.skyrim_shader_type = NifFormat.BSLightingShaderPropertyShaderType._enumvalues[b_s_type]
 
         self.texturehelper.export_bs_lighting_shader_prop_textures(bsshader)
 

--- a/io_scene_nif/modules/nif_import/geometry/mesh/__init__.py
+++ b/io_scene_nif/modules/nif_import/geometry/mesh/__init__.py
@@ -62,15 +62,13 @@ class Mesh:
         self.morph_anim = MorphAnimation()
         self.mesh_prop_processor = MeshPropertyProcessor()
 
-    def import_mesh(self, n_block, b_obj, transform=None):
+    def import_mesh(self, n_block, b_obj):
         """Creates and returns a raw mesh, or appends geometry data to group_mesh.
 
         :param n_block: The nif block whose mesh data to import.
         :type n_block: C{NiTriBasedGeom}
         :param b_obj: The mesh to which to append the geometry data. If C{None}, a new mesh is created.
         :type b_obj: A Blender object that has mesh data.
-        :param transform: Apply the n_block's transformation to the mesh.
-        :type transform: C{Matix}
         """
         assert (isinstance(n_block, NifFormat.NiTriBasedGeom))
 
@@ -92,7 +90,7 @@ class Mesh:
         # TODO [properties] Should this be object level process, secondary pass for materials / caching
         self.mesh_prop_processor.process_property_list(n_block, b_obj.data)
 
-        v_map = Mesh.map_n_verts_to_b_verts(b_mesh, n_tri_data, transform)
+        v_map = Mesh.map_n_verts_to_b_verts(b_mesh, n_tri_data)
 
         bf2_index, f_map = Mesh.add_triangles_to_bmesh(b_mesh, n_triangles, v_map)
 
@@ -185,7 +183,7 @@ class Mesh:
         return b_poly_offset, f_map
 
     @staticmethod
-    def map_n_verts_to_b_verts(b_mesh, n_tri_data, transform):
+    def map_n_verts_to_b_verts(b_mesh, n_tri_data):
         # vertices
         n_verts = n_tri_data.vertices
 
@@ -232,9 +230,6 @@ class Mesh:
                 # no entry: new vertex / normal pair
                 n_map[key] = n_vert_index  # unique vertex / normal pair with key k was added, with NIF index i
                 v_map[n_vert_index] = b_v_index  # NIF vertex i maps to blender vertex b_v_index
-                if transform:
-                    n_vert = mathutils.Vector([n_vert.x, n_vert.y, n_vert.z])
-                    n_vert = transform * n_vert
 
                 # add the vertex
                 b_mesh.vertices.add(1)

--- a/io_scene_nif/modules/nif_import/geometry/mesh/__init__.py
+++ b/io_scene_nif/modules/nif_import/geometry/mesh/__init__.py
@@ -234,7 +234,7 @@ class Mesh:
                 v_map[n_vert_index] = b_v_index  # NIF vertex i maps to blender vertex b_v_index
                 if transform:
                     n_vert = mathutils.Vector([n_vert.x, n_vert.y, n_vert.z])
-                    n_vert = n_vert * transform
+                    n_vert = transform * n_vert
 
                 # add the vertex
                 b_mesh.vertices.add(1)

--- a/io_scene_nif/modules/nif_import/object/__init__.py
+++ b/io_scene_nif/modules/nif_import/object/__init__.py
@@ -200,8 +200,8 @@ class Object:
     def import_geometry_object(self, b_armature, n_block):
         # it's a shape node and we're not importing skeleton only
         b_obj = self.create_mesh_object(n_block)
-        transform = util_math.import_matrix(n_block)  # set transform matrix for the mesh
-        self.mesh.import_mesh(n_block, b_obj, transform)
+        b_obj.matrix_local = util_math.import_matrix(n_block)  # set transform matrix for the mesh
+        self.mesh.import_mesh(n_block, b_obj)
         bpy.context.scene.objects.active = b_obj
         # store flags etc
         self.import_object_flags(n_block, b_obj)

--- a/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
@@ -144,6 +144,10 @@ class BSShaderPropertyProcessor(BSShader):
         # if n_alpha_prop:
         #     b_mat = self.set_alpha_bsshader(b_mat, bs_shader_property)
 
+        #Emissive color
+        Material.import_material_emissive(self._b_mat, bs_shader_property.emissive_color)
+        self._b_mat.emit = bs_shader_property.emissive_multiple
+
         # gloss
         Material.import_material_gloss(self._b_mat, bs_shader_property.glossiness)
 

--- a/io_scene_nif/properties/shader.py
+++ b/io_scene_nif/properties/shader.py
@@ -237,8 +237,8 @@ class ShaderProps(PropertyGroup):
             name='Use Falloff'
         )
 
-        cls.slsf_1_enviroment_mapping = BoolProperty(
-            name='Enviroment Mapping'
+        cls.slsf_1_environment_mapping = BoolProperty(
+            name='Environment Mapping'
         )
 
         cls.slsf_1_recieve_shadows = BoolProperty(

--- a/io_scene_nif/ui/shader.py
+++ b/io_scene_nif/ui/shader.py
@@ -102,7 +102,7 @@ class ObjectShader(Panel):
             row.prop(nif_obj_props, "slsf_1_cast_shadows")
             row.prop(nif_obj_props, "slsf_1_decal")
             row.prop(nif_obj_props, "slsf_1_dynamic_decal")
-            row.prop(nif_obj_props, "slsf_1_enviroment_mapping")
+            row.prop(nif_obj_props, "slsf_1_environment_mapping")
             row.prop(nif_obj_props, "slsf_1_external_emittance")
             row.prop(nif_obj_props, "slsf_1_eye_environment_mapping")
             row.prop(nif_obj_props, "slsf_1_facegen_detail")


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Commented out code in collision export which led to errors (taken from develop branch). Implemented NiTriShape transform import to Blender tranform (taken from develop branch). Fixes to BSLightingShaderProperty environment mapping flag import/export, shader type export and emissive color import.

##  Detailed Description
* Implemented NiTriShape transform to Blender transform from develop branch. This means that the tranforms on a NiTriShape are now imported as Blender transforms, instead of being (previously incorrectly) applied within the import. Export already converts between the two.
* Commented out code from collision export which led to errors. This was also commented out in the develop branch, but probably will need updating in the future.
* Fixed the spelling of the environment map flag in the UI. The misspelling meant that the flag was not set upon import, and even when setting the flag upon export, it would not be reflected in the exported nif.
* Fixed the BSLightingShaderProperty Skyrim Shader Type export setting. The current code set the wrong property, meaning that it would always export to Default (instead of, for example, Environment Map or Glow Shader).
* Brought the BSLightingShaderProperty emissive color/multiple import in line with how the BSEffectShaderProperty imported it, as well as with how it is exported, meaning that import and subsequent export will give the same emissive color/multiple as in the original nif.

## Fixes Known Issues
Issues were not known beforehand.

## Documentation
[Overview of updates to documentation]

## Testing
* Import and export this mesh: https://cdn.discordapp.com/attachments/702566403605266435/714109082793017404/irondaggerEmissiveTest.nif
Within the IronDagger01:0 NiTriShape's BSLightingShaderProperty, the Environment Mapping flag, the emissive multiple, the emissive color and the Skyrim Shader Type should be the same as on the original mesh.
* Import this mesh: https://cdn.discordapp.com/attachments/702566403605266435/714116853596946462/irondaggerTestTransforms.nif
The position and orientation of the scabbard should be identical within the nif and the blend file. Upon export the transforms on the NiTriShape (Translation, Rotation and scale) should be the same as in the original nif.

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

