### PR TITLE
Fix/bss shader node setup

### DIFF
--- a/io_scene_nif/modules/nif_export/property/texture/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/texture/__init__.py
@@ -88,9 +88,8 @@ class TextureSlotManager:
         elif isinstance(uv_node, bpy.types.ShaderNodeTexCoord):
             return "REFLECT"
         else:
-            raise util_math.NifError(f"Unsupported vector input for {b_texture_node.name} in material '{b_mat.name}''.\n"
+            raise util_math.NifError(f"Unsupported vector input for {b_texture_node.name} in material '{self.b_mat.name}''.\n"
                                      f"Expected 'UV Map' or 'Texture Coordinate' nodes")
-
 
     @staticmethod
     def get_used_textslots(b_mat):

--- a/io_scene_nif/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_nif/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -63,10 +63,10 @@ class BSShaderTexture(TextureSlotManager):
     def export_bs_effect_shader_prop_textures(self, bsshader):
         bsshader.texture_set = self._create_textureset()
 
-        if self.b_diffuse_slot:
-            bsshader.source_texture = TextureWriter.export_texture_filename(self.b_diffuse_slot.texture)
-        if self.b_glow_slot:
-            bsshader.greyscale_texture = TextureWriter.export_texture_filename(self.b_glow_slot.texture)
+        if self.slots["Base"]:
+            bsshader.source_texture = TextureWriter.export_texture_filename(self.slots["Base"])
+        if self.slots["Glow"]:
+            bsshader.greyscale_texture = TextureWriter.export_texture_filename(self.slots["Glow"])
 
         # clamp Mode
         bsshader.texture_clamp_mode = 65283
@@ -79,26 +79,27 @@ class BSShaderTexture(TextureSlotManager):
         texset.num_textures = 9
         texset.textures.update_size()
 
-        if self.b_detail_slot:
-            texset.textures[6] = TextureWriter.export_texture_filename(self.b_detail_slot.texture)
+        if self.slots["Detail"]:
+            texset.textures[6] = TextureWriter.export_texture_filename(self.slots["Detail"])
 
-        if self.b_gloss_slot:
-            texset.textures[7] = TextureWriter.export_texture_filename(self.b_gloss_slot.texture)
+        if self.slots["Gloss"]:
+            texset.textures[7] = TextureWriter.export_texture_filename(self.slots["Gloss"])
 
-        # UV Offset
-        if hasattr(bsshader, 'uv_offset'):
-            self.export_uv_offset(bsshader)
-
-        # UV Scale
-        if hasattr(bsshader, 'uv_scale'):
-            self.export_uv_scale(bsshader)
+        # # UV Offset
+        # if hasattr(bsshader, 'uv_offset'):
+        #     self.export_uv_offset(bsshader)
+        #
+        # # UV Scale
+        # if hasattr(bsshader, 'uv_scale'):
+        #     self.export_uv_scale(bsshader)
 
         # Texture Clamping mode
-        if not self.b_diffuse_slot.texture.image.use_clamp_x:
+        b_img = self.slots["Base"].image
+        if not b_img.use_clamp_x:
             wrap_s = 2
         else:
             wrap_s = 0
-        if not self.b_diffuse_slot.texture.image.use_clamp_y:
+        if not b_img.use_clamp_y:
             wrap_t = 1
         else:
             wrap_t = 0
@@ -111,28 +112,28 @@ class BSShaderTexture(TextureSlotManager):
     def _create_textureset(self):
         texset = NifFormat.BSShaderTextureSet()
 
-        if self.b_diffuse_slot:
-            texset.textures[0] = TextureWriter.export_texture_filename(self.b_diffuse_slot.texture)
+        if self.slots["Base"]:
+            texset.textures[0] = TextureWriter.export_texture_filename(self.slots["Base"])
 
-        if self.b_normal_slot:
-            texset.textures[1] = TextureWriter.export_texture_filename(self.b_normal_slot.texture)
+        if self.slots["Normal"]:
+            texset.textures[1] = TextureWriter.export_texture_filename(self.slots["Normal"])
 
-        if self.b_glow_slot:
-            texset.textures[2] = TextureWriter.export_texture_filename(self.b_glow_slot.texture)
+        if self.slots["Glow"]:
+            texset.textures[2] = TextureWriter.export_texture_filename(self.slots["Glow"])
 
-        if self.b_detail_slot:
-            texset.textures[3] = TextureWriter.export_texture_filename(self.b_detail_slot.texture)
+        if self.slots["Detail"]:
+            texset.textures[3] = TextureWriter.export_texture_filename(self.slots["Detail"])
 
         return texset
 
     def export_uv_offset(self, shader):
-        shader.uv_offset.u = self.b_diffuse_slot.offset.x
-        shader.uv_offset.v = self.b_diffuse_slot.offset.y
+        shader.uv_offset.u = self.slots["Base"].offset.x
+        shader.uv_offset.v = self.slots["Base"].offset.y
 
         return shader
 
     def export_uv_scale(self, shader):
-        shader.uv_scale.u = self.b_diffuse_slot.scale.x
-        shader.uv_scale.v = self.b_diffuse_slot.scale.y
+        shader.uv_scale.u = self.slots["Base"].scale.x
+        shader.uv_scale.v = self.slots["Base"].scale.y
 
         return shader

--- a/io_scene_nif/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_nif/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -85,6 +85,7 @@ class BSShaderTexture(TextureSlotManager):
         if self.slots["Gloss"]:
             texset.textures[7] = TextureWriter.export_texture_filename(self.slots["Gloss"])
 
+        # TODO [shader] UV offset node support
         # # UV Offset
         # if hasattr(bsshader, 'uv_offset'):
         #     self.export_uv_offset(bsshader)

--- a/io_scene_nif/modules/nif_import/property/geometry/mesh.py
+++ b/io_scene_nif/modules/nif_import/property/geometry/mesh.py
@@ -37,11 +37,11 @@
 #
 # ***** END LICENSE BLOCK *****
 
-from functools import singledispatch
-import itertools
 import bpy
 
-from io_scene_nif.modules.nif_import.property.texture.types.nitextureprop import NiTextureProp
+from functools import singledispatch
+import itertools
+
 from io_scene_nif.modules.nif_import.property.geometry.niproperty import NiPropertyProcessor
 from io_scene_nif.modules.nif_import.property.nodes_wrapper import NodesWrapper
 from io_scene_nif.modules.nif_import.property.shader.bsshaderlightingproperty import BSShaderLightingPropertyProcessor
@@ -109,7 +109,6 @@ class MeshPropertyProcessor:
             self.process_property(prop)
 
         self.nodes_wrapper.connect_to_output(b_mesh.vertex_colors)
-
 
     def process_property(self, prop):
         """Base method to warn user that this property is not supported"""

--- a/io_scene_nif/modules/nif_import/property/geometry/niproperty.py
+++ b/io_scene_nif/modules/nif_import/property/geometry/niproperty.py
@@ -37,7 +37,6 @@
 #
 # ***** END LICENSE BLOCK *****
 
-import bpy
 from pyffi.formats.nif import NifFormat
 
 from io_scene_nif.modules.nif_import.animation.material import MaterialAnimation

--- a/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
+++ b/io_scene_nif/modules/nif_import/property/shader/bsshaderproperty.py
@@ -117,7 +117,7 @@ class BSShaderPropertyProcessor(BSShader):
         # Textures
         self.texturehelper.import_bsshaderproperty_textureset(bs_shader_property, self._nodes_wrapper)
 
-        # todo [material] update for nodes
+        # TODO [shader] UV offset node support
         # if hasattr(bs_shader_property, 'texture_clamp_mode'):
         #     self.import_clamp(self.b_mat, bs_shader_property)
         #


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
[Overview of the content of the pull request]
Update Skyrim shader minimal support to Blender 2.8

##  Detailed Description
[List of functional updates]
- Update the calls to use b_texture_slots
- Disable the support for uv_offset on export as not setup currently on import

## Fixes Known Issues
[Ordered list of issues fixed by this PR]

## Documentation
[Overview of updates to documentation]
Uses existing node slot names.

## Testing
[Overview of testing required to ensure functionality is correctly implemented]
Imported skyrim nif successfully

### Manual
[Order steps to manually verify updates are working correctly]
Manually imported `Male_body1.nif` and then direct export

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

