### PR TITLE
Bug/export disable clamp mode

### DIFF
--- a/io_scene_nif/modules/nif_export/property/object/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/object/__init__.py
@@ -83,10 +83,9 @@ class ObjectProperty:
                 bsshader = self.bss_helper.export_bs_shader_property(b_mat)
 
                 block_store.register_block(bsshader)
-                num_props = n_block.num_properties
-                n_block.num_properties = num_props + 1
+                # TODO [pyffi] Add helper function to allow adding bs_property / general list addition
+                n_block.bs_properties[0] = bsshader
                 n_block.bs_properties.update_size()
-                n_block.bs_properties[num_props] = bsshader
 
             else:
                 if bpy.context.scene.niftools_scene.game in self.texture_helper.USED_EXTRA_SHADER_TEXTURES:

--- a/io_scene_nif/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/shader/__init__.py
@@ -114,7 +114,7 @@ class BSShaderProperty:
         bsshader.emissive_multiple = b_mat.emit
 
         # gloss
-        bsshader.glossiness = b_mat.specular_hardness
+        bsshader.glossiness = b_mat.roughness
 
         # Specular color
         bsshader.specular_color.r = b_mat.specular_color.r

--- a/io_scene_nif/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/shader/__init__.py
@@ -121,9 +121,10 @@ class BSShaderProperty:
         bsshader.glossiness = b_mat.roughness
 
         # Specular color
-        bsshader.specular_color.r = b_mat.specular_color.r
-        bsshader.specular_color.g = b_mat.specular_color.g
-        bsshader.specular_color.b = b_mat.specular_color.b
+        s = b_mat.specular_color
+        bsshader.specular_color.r = s[0]
+        bsshader.specular_color.g = s[1]
+        bsshader.specular_color.b = s[2]
         bsshader.specular_strength = b_mat.specular_intensity
 
         # Alpha

--- a/io_scene_nif/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/shader/__init__.py
@@ -110,10 +110,12 @@ class BSShaderProperty:
         bsshader.lighting_effect_2 = b_mat.niftools.lightingeffect2
 
         # Emissive
-        bsshader.emissive_color.r = b_mat.niftools.emissive_color.r
-        bsshader.emissive_color.g = b_mat.niftools.emissive_color.g
-        bsshader.emissive_color.b = b_mat.niftools.emissive_color.b
-        bsshader.emissive_multiple = b_mat.emit
+        e = b_mat.niftools.emissive_color
+        bsshader.emissive_color.r = e[0]
+        bsshader.emissive_color.g = e[1]
+        bsshader.emissive_color.b = e[2]
+        # TODO [shader] Expose a emission multiplier value
+        # bsshader.emissive_multiple = b_mat.emit
 
         # gloss
         bsshader.glossiness = b_mat.roughness

--- a/io_scene_nif/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/shader/__init__.py
@@ -99,9 +99,11 @@ class BSShaderProperty:
         self.texturehelper.export_bs_lighting_shader_prop_textures(bsshader)
 
         # Diffuse color
-        bsshader.skin_tint_color.r = b_mat.diffuse_color.r
-        bsshader.skin_tint_color.g = b_mat.diffuse_color.g
-        bsshader.skin_tint_color.b = b_mat.diffuse_color.b
+        d = b_mat.diffuse_color
+        bsshader.skin_tint_color.r = d[0]
+        bsshader.skin_tint_color.g = d[1]
+        bsshader.skin_tint_color.b = d[2]
+        # TODO [shader] expose intensity value
         # b_mat.diffuse_intensity = 1.0
 
         bsshader.lighting_effect_1 = b_mat.niftools.lightingeffect1

--- a/io_scene_nif/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/shader/__init__.py
@@ -73,8 +73,9 @@ class BSShaderProperty:
         self.texturehelper.export_bs_effect_shader_prop_textures(bsshader)
 
         # Alpha
-        if b_mat.use_transparency:
-            bsshader.alpha = (1 - b_mat.alpha)
+        # TODO [Shader] Alpha property
+        # if b_mat.use_transparency:
+        #     bsshader.alpha = (1 - b_mat.alpha)
 
         # clamp Mode
         bsshader.texture_clamp_mode = 65283
@@ -128,8 +129,9 @@ class BSShaderProperty:
         bsshader.specular_strength = b_mat.specular_intensity
 
         # Alpha
-        if b_mat.use_transparency:
-            bsshader.alpha = (1 - b_mat.alpha)
+        # TODO [Shader] Alpha property
+        # if b_mat.use_transparency:
+        #     bsshader.alpha = (1 - b_mat.alpha)
 
         # Shader Flags
         BSShaderProperty.export_shader_flags(b_mat, bsshader)

--- a/io_scene_nif/modules/nif_export/property/texture/types/bsshadertexture.py
+++ b/io_scene_nif/modules/nif_export/property/texture/types/bsshadertexture.py
@@ -96,16 +96,17 @@ class BSShaderTexture(TextureSlotManager):
 
         # Texture Clamping mode
         b_img = self.slots["Base"].image
-        if not b_img.use_clamp_x:
-            wrap_s = 2
-        else:
-            wrap_s = 0
-        if not b_img.use_clamp_y:
-            wrap_t = 1
-        else:
-            wrap_t = 0
-            
-        bsshader.texture_clamp_mode = (wrap_s + wrap_t)
+        # TODO [texture] Implement clamp on image wrapping
+        # if not b_img.use_clamp_x:
+        #     wrap_s = 2
+        # else:
+        #     wrap_s = 0
+        # if not b_img.use_clamp_y:
+        #     wrap_t = 1
+        # else:
+        #     wrap_t = 0
+        #
+        # bsshader.texture_clamp_mode = (wrap_s + wrap_t)
 
     def export_bs_shader_pp_lighting_prop_textures(self, bsshader):
         bsshader.texture_set = self._create_textureset()

--- a/io_scene_nif/modules/nif_import/property/material/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/material/__init__.py
@@ -69,7 +69,7 @@ class Material:
             b_mat.blend_method = "OPAQUE"
             b_mat.shadow_method = "OPAQUE"
 
-        b_mat.alpha_threshold = n_alpha_prop.threshold / 255 # transparency threshold
+        b_mat.alpha_threshold = n_alpha_prop.threshold / 255  # transparency threshold
         b_mat.niftools_alpha.alphaflag = n_alpha_prop.flags
 
         return b_mat
@@ -98,6 +98,7 @@ class Material:
 
     @staticmethod
     def import_material_alpha(b_mat, n_alpha):
+        # TODO [Shader] Alpha property
         b_mat.niftools.emissive_alpha.v = n_alpha
 
 

--- a/io_scene_nif/modules/nif_import/property/material/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/material/__init__.py
@@ -94,11 +94,12 @@ class Material:
     @staticmethod
     def import_material_gloss(b_mat, glossiness):
         # b_mat.specular_hardness = glossiness
-        b_mat.specular_intensity = glossiness  # Blender multiplies specular color with this value
+        b_mat.roughness = glossiness  # Blender multiplies specular color with this value
 
     @staticmethod
     def import_material_alpha(b_mat, n_alpha):
         b_mat.niftools.emissive_alpha.v = n_alpha
+
 
 class NiMaterial(Material):
 

--- a/io_scene_nif/modules/nif_import/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/shader/__init__.py
@@ -50,6 +50,7 @@ class BSShader(ABC):
     def __init__(self):
         self.b_mesh = None
 
+    # TODO [texture] Implement clamp on image wrapping
     @staticmethod
     def import_uv_offset(b_mat, shader_prop):
         for texture_slot in b_mat.texture_slots:
@@ -57,6 +58,7 @@ class BSShader(ABC):
                 texture_slot.offset.x = shader_prop.uv_offset.u
                 texture_slot.offset.y = shader_prop.uv_offset.v
 
+    # TODO [texture] Implement clamp on image wrapping
     @staticmethod
     def import_uv_scale(b_mat, shader_prop):
         for texture_slot in b_mat.texture_slots:
@@ -64,23 +66,24 @@ class BSShader(ABC):
                 texture_slot.scale.x = shader_prop.uv_scale.u
                 texture_slot.scale.y = shader_prop.uv_scale.v
 
+    # TODO [texture] Implement clamp on image wrapping
     @staticmethod
     def import_clamp(b_mat, shader_prop):
         clamp = shader_prop.texture_clamp_mode
         for texture_slot in b_mat.texture_slots:
             if texture_slot:
                 if clamp == 3:
-                    texture_slot.texture.image.use_clamp_x = False
-                    texture_slot.texture.image.use_clamp_y = False
+                    texture_slot.image.use_clamp_x = False
+                    texture_slot.image.use_clamp_y = False
                 if clamp == 2:
-                    texture_slot.texture.image.use_clamp_x = False
-                    texture_slot.texture.image.use_clamp_y = True
+                    texture_slot.image.use_clamp_x = False
+                    texture_slot.image.use_clamp_y = True
                 if clamp == 1:
-                    texture_slot.texture.image.use_clamp_x = True
-                    texture_slot.texture.image.use_clamp_y = False
+                    texture_slot.image.use_clamp_x = True
+                    texture_slot.image.use_clamp_y = False
                 if clamp == 0:
-                    texture_slot.texture.image.use_clamp_x = True
-                    texture_slot.texture.image.use_clamp_y = True
+                    texture_slot.image.use_clamp_x = True
+                    texture_slot.image.use_clamp_y = True
 
     @staticmethod
     def set_alpha_bsshader(b_mat, shader_property):

--- a/io_scene_nif/modules/nif_import/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/shader/__init__.py
@@ -85,6 +85,7 @@ class BSShader(ABC):
                     texture_slot.image.use_clamp_x = True
                     texture_slot.image.use_clamp_y = True
 
+    # TODO [Shader] Alpha property
     @staticmethod
     def set_alpha_bsshader(b_mat, shader_property):
         NifLog.debug("Alpha prop detected")

--- a/io_scene_nif/modules/nif_import/property/shader/bsshaderlightingproperty.py
+++ b/io_scene_nif/modules/nif_import/property/shader/bsshaderlightingproperty.py
@@ -37,11 +37,8 @@
 #
 # ***** END LICENSE BLOCK *****
 
-import bpy
-
 from pyffi.formats.nif import NifFormat
 
-from io_scene_nif.modules.nif_import.object.block_registry import block_store
 from io_scene_nif.modules.nif_import.property.shader import BSShader
 from io_scene_nif.modules.nif_import.property.texture.types.bsshadertexture import BSShaderTexture
 


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
[Overview of the content of the pull request]
Disable BSShader features to allow export to finish to completion

##  Detailed Description
[List of functional updates]
- Fix registering BSShader in bs_properties list
- Disable alpha export as not supported on import
- Fix skin_tint, specular_color & emissive color type access
- Disable emissive multiplies export as not supported on import
- Fix & align specular roughness mapping in import & export
- Disable texture clamping as removed when ported to 2.8X

## Fixes Known Issues
[Ordered list of issues fixed by this PR]

## Documentation
[Overview of updates to documentation]

## Testing
[Overview of testing required to ensure functionality is correctly implemented]
Tested with user provided nif - [FS7_Glovess_1.nif.zip](https://github.com/niftools/blender_nif_plugin/files/4713273/FS7_Glovess_1.nif.zip)

### Manual
[Order steps to manually verify updates are working correctly]
Import and export complete succesfully, data might be missing 

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

