### PR TITLE
Fix to bhkBoxShape and bhkSphereShape translation export.

### DIFF
--- a/io_scene_nif/modules/nif_export/collision/havok.py
+++ b/io_scene_nif/modules/nif_export/collision/havok.py
@@ -367,9 +367,9 @@ class BhkCollision(Collision):
             n_coltf.transform.set_rows(*hktf)
 
             # fix matrix for havok coordinate system
-            n_coltf.transform.m_41 /= self.HAVOK_SCALE
-            n_coltf.transform.m_42 /= self.HAVOK_SCALE
-            n_coltf.transform.m_43 /= self.HAVOK_SCALE
+            n_coltf.transform.m_14 /= self.HAVOK_SCALE
+            n_coltf.transform.m_24 /= self.HAVOK_SCALE
+            n_coltf.transform.m_34 /= self.HAVOK_SCALE
 
             if b_obj.game.collision_bounds_type == 'BOX':
                 n_colbox = block_store.create_block("bhkBoxShape", b_obj)


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Fix to bhkBoxShape and bhkSphereShape translation export.

##  Detailed Description
Because the transform matrix is transposed to how it is displayed in NifSkope, the inverse havok scale was applied to the wrong matrix elements, which is now fixed.

## Fixes Known Issues
Issues not in issues list

## Documentation
No updates to documentation.

## Testing
Export a bhkSphereShape or bhkBoxShape with a non-zero translation. Within NifSkope, this translation should be (displayed) the same, i.e. the translation should be the Blender translation divided by the havok scale.

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

