### PR TITLE
Fix to bhkBoxShape and bhkSphereShape translation export and documentation update.

### DIFF
--- a/docs/development/setup/environment.rst
+++ b/docs/development/setup/environment.rst
@@ -48,8 +48,8 @@ Environment Variables
 
 **Windows**::
 
-    set /p BLENDER_ADDONS_DIR=<path_to_blender_addons>
-    set /p BLENDER_HOME="<path_to_blender_exe>"
+    set BLENDER_ADDONS_DIR=<path_to_blender_addons>
+    set BLENDER_HOME=<path_to_blender_exe>
 
 **Ubuntu**::
     set -X BLENDER_ADDONS_DIR=<path_to_blender_addons>

--- a/io_scene_nif/modules/nif_export/collision/havok.py
+++ b/io_scene_nif/modules/nif_export/collision/havok.py
@@ -372,9 +372,9 @@ class BhkCollision(Collision):
             n_coltf.transform.set_rows(*hktf)
 
             # fix matrix for havok coordinate system
-            n_coltf.transform.m_41 /= self.HAVOK_SCALE
-            n_coltf.transform.m_42 /= self.HAVOK_SCALE
-            n_coltf.transform.m_43 /= self.HAVOK_SCALE
+            n_coltf.transform.m_14 /= self.HAVOK_SCALE
+            n_coltf.transform.m_24 /= self.HAVOK_SCALE
+            n_coltf.transform.m_34 /= self.HAVOK_SCALE
 
             if collision_shape == 'BOX':
                 n_colbox = block_store.create_block("bhkBoxShape", b_obj)


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
* Fix to bhkBoxShape and bhkSphereShape translation export where inverted havok scale was not applied
* Documentation update for setting environment variables on Windows

##  Detailed Description
* Because the transform matrix is transposed to how it is displayed in NifSkope, the inverse havok scale was applied to the wrong matrix elements, which is now fixed.
* The documentation used `SET /p`, but this gives a prompt rather than directly setting the variable. The `/p` was removed.

## Fixes Known Issues
Issues not in issues list

## Documentation
The `SET` command example in the documentation was changed so that it directly sets the variable rather than giving a prompt and the user having to enter it again.

## Testing
Export a bhkSphereShape or bhkBoxShape with a non-zero translation. Within NifSkope, this translation should be (displayed) the same, i.e. the translation should be the Blender translation divided by the havok scale.

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

