### PR TITLE
Update transform.py

### DIFF
--- a/io_scene_nif/modules/nif_export/animation/transform.py
+++ b/io_scene_nif/modules/nif_export/animation/transform.py
@@ -314,7 +314,7 @@ class TransformAnimation(Animation):
                     key.time = frame / self.fps
                     key.value = euler[i]
         elif quat_curve:
-            n_kfd.rotation_type = NifFormat.KeyType.LINEAR_KEY
+            n_kfd.rotation_type = NifFormat.KeyType.QUADRATIC_KEY
             n_kfd.num_rotation_keys = len(quat_curve)
             n_kfd.quaternion_keys.update_size()
             for key, (frame, quat) in zip(n_kfd.quaternion_keys, quat_curve):


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
Wrong key type for Quadratic Curve. 

##  Detailed Description
[List of functional updates]
When set to Linear, animations work in Nifskope, but it fall apart when moved to Skyrim SE
Simple change to key type

## Fixes Known Issues
[Ordered list of issues fixed by this PR]

## Documentation
[Overview of updates to documentation]

## Testing
Exported KF appears to work in NifSkope, but is completely off when moved to Havok Tools.

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

