### PR TITLE
Bug fixes to zip generation, BSEffecShaderProperty export, and meshes parented to armature. Also game set on import.

### DIFF
--- a/install/install.bat
+++ b/install/install.bat
@@ -32,6 +32,6 @@ echo.Removing old installation
 if exist "%BLENDER_ADDONS_DIR%\io_scene_nif" rmdir /s /q "%BLENDER_ADDONS_DIR%\io_scene_nif"
 
 :: copy files from repository to blender addons folder
-powershell -executionpolicy bypass -Command "%DIR%\unzip.ps1" -source '%DIR%\%ZIP_NAME%.zip' -destination '%BLENDER_ADDONS_DIR%\io_scene_nif'
+powershell -executionpolicy bypass -Command "%DIR%\unzip.ps1" -source '%DIR%\%ZIP_NAME%.zip' -destination '%BLENDER_ADDONS_DIR%'
 
 :end

--- a/install/unzip.ps1
+++ b/install/unzip.ps1
@@ -6,12 +6,6 @@ param (
 write ("Source : {0}" -f $source)
 write ("Destination : {0}" -f $destination)
 
-If(Test-path $destination) {
-write ("Ensuring existing folder is removed {0}" -f $destination)
-Remove-item $destination
-write ("Success")
-}
-
 Add-Type -assembly "system.io.compression.filesystem"
 [io.compression.zipFile]::ExtractToDirectory($source, $destination)
 

--- a/install/zip.ps1
+++ b/install/zip.ps1
@@ -13,7 +13,7 @@ write ("Existing archive removed successfully")
 }
 
 Add-Type -assembly "system.io.compression.filesystem"
-[io.compression.zipfile]::CreateFromDirectory($source, $destination)
+[io.compression.zipfile]::CreateFromDirectory($source, $destination, 1, 1)
 If(Test-path $destination) {
     write("File successully written")
 }

--- a/io_scene_nif/modules/nif_export/object/__init__.py
+++ b/io_scene_nif/modules/nif_export/object/__init__.py
@@ -223,14 +223,15 @@ class Object:
         """Export all children of blender object b_parent as children of n_parent."""
         # loop over all obj's children
         for b_child in b_parent.children:
+            temp_parent = n_parent
             # special case: objects parented to armature bones - find the nif parent bone
             if b_parent.type == 'ARMATURE' and b_child.parent_bone != "":
                 parent_bone = b_parent.data.bones[b_child.parent_bone]
                 assert (parent_bone in block_store.block_to_obj.values())
-                for n_parent, obj in block_store.block_to_obj.items():
+                for temp_parent, obj in block_store.block_to_obj.items():
                     if obj == parent_bone:
                         break
-            self.export_node(b_child, n_parent)
+            self.export_node(b_child, temp_parent)
 
     def export_collision(self, b_obj, n_parent):
         """Main function for adding collision object b_obj to a node.

--- a/io_scene_nif/modules/nif_export/property/shader/__init__.py
+++ b/io_scene_nif/modules/nif_export/property/shader/__init__.py
@@ -85,7 +85,8 @@ class BSShaderProperty:
         bsshader.emissive_color.g = b_mat.niftools.emissive_color.g
         bsshader.emissive_color.b = b_mat.niftools.emissive_color.b
         bsshader.emissive_color.a = b_mat.niftools.emissive_alpha.v
-        bsshader.emissive_multiple = b_mat.emit
+        # TODO [shader] Expose a emission multiplier value
+        # bsshader.emissive_multiple = b_mat.emit
 
         # Shader Flags
         BSShaderProperty.export_shader_flags(b_mat, bsshader)

--- a/io_scene_nif/modules/nif_export/scene/__init__.py
+++ b/io_scene_nif/modules/nif_export/scene/__init__.py
@@ -42,21 +42,6 @@ from io_scene_nif.utils.util_global import NifOp
 from io_scene_nif.utils.util_logging import NifLog
 from pyffi.formats.nif import NifFormat
 
-# TODO [scene] Use this as global import and export values and remove from operator
-USER_VERSION = {
-    'OBLIVION': 11,
-    'FALLOUT_3': 11,
-    'SKYRIM': 12,
-    'DIVINITY_2': 131072
-}
-
-USER_VERSION_2 = {
-    'OBLIVION': 11,
-    'FALLOUT_3': 34,
-    'SKYRIM': 83
-}
-
-
 def get_version_data():
     """ Returns NifFormat.Data of the correct version and user versions """
     b_scene = bpy.context.scene.niftools_scene
@@ -65,7 +50,7 @@ def get_version_data():
     NifLog.info("Writing NIF version 0x%08X" % version)
 
     # get user version and user version 2 for export
-    user_version = b_scene.user_version if b_scene.user_version else USER_VERSION.get(game, 0)
-    user_version_2 = b_scene.user_version_2 if b_scene.user_version_2 else USER_VERSION_2.get(game, 0)
+    user_version = b_scene.user_version if b_scene.user_version else b_scene.USER_VERSION.get(game, 0)
+    user_version_2 = b_scene.user_version_2 if b_scene.user_version_2 else b_scene.USER_VERSION_2.get(game, 0)
 
     return version, NifFormat.Data(version, user_version, user_version_2)

--- a/io_scene_nif/modules/nif_import/scene/__init__.py
+++ b/io_scene_nif/modules/nif_import/scene/__init__.py
@@ -48,27 +48,28 @@ def import_version_info(data):
     scene.user_version_2 = data._user_version_2_value_._value
     
     #filter possible games by nif version
-    possible_games = set()
+    possible_games = []
     for game, versions in NifFormat.games.items():
         if game != '?':
             if scene.nif_version in versions:
-                possible_games.add(_game_to_enum(game))
-    #filter possible games by user version
-    for game in list(possible_games):
-        if game in scene.USER_VERSION:
-            if scene.USER_VERSION[game] != scene.user_version:
-                possible_games.remove(game)
-        else:
-            if scene.user_version != 0:
-                possible_games.remove(game)
-    #filter possible games by user version 2
-    for game in list(possible_games):
-        if game in scene.USER_VERSION_2:
-            if scene.USER_VERSION_2[game] != scene.user_version_2:
-                possible_games.remove(game)
-        else:
-            if scene.user_version != 0:
-                possible_games.remove(game)
-    #only set the game if it is unambiguous from which game it came
+                game_enum = _game_to_enum(game)
+                #go to next game if user version for this game does not match defined
+                if game_enum in scene.USER_VERSION:
+                    if scene.USER_VERSION[game_enum] != scene.user_version:
+                        continue
+                #or user version in scene is not 0 when this game has no associated user version
+                elif scene.user_version != 0:
+                    continue
+                #same checks for user version 2
+                if game_enum in scene.USER_VERSION_2:
+                    if scene.USER_VERSION_2[game_enum] != scene.user_version:
+                        continue
+                elif scene.user_version_2 != 0:
+                    continue
+                #passed all checks, add to possible games list
+                possible_games.append(game_enum)
     if len(possible_games) == 1:
-        scene.game = possible_games.pop()
+        scene.game = possible_games[0]
+    elif len(possible_games) > 1:
+        scene.game = possible_games[0]
+        NifLog.warn(f"Game set to '{possible_games[0]}', but multiple games qualified")


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
* Game version is now set on import based also on user version and user version 2
* Zip generation bat file now includes io_scene_nif within the zip.
* No emission value error when exporting BSEffectShaderProperty
* No incorrectly parented objects when they are alphabetically lower than collision objects of an armature.

##  Detailed Description
* User versions associated with games is now only defined in one place: io_scene_nif/properties/scene.py and used from there even in the export.
* Game is first assumed to be anything, then filtered by nif version, then by user version (if the game does not have an associated user version, it is assumed that that user version should be 0).
* Make use of the extra arguments for CreateFromDirectory to include the folder within the zip file.
* Emission setting for BSEffectShaderProperty was simply commented out, in line with BSLightingShaderProperty
* Used a variable temp_parent for every loop of export_children so that the original n_parent parameter does not get overwritten for all subsequent children when exporting collision parented to an armature.

## Fixes Known Issues
Closes #373 

## Documentation
[Overview of updates to documentation]

## Testing
Exporting the blend file attached to #373 should now lead to the same export as the Lantern_Rigged_renamed.nif.

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

