### PR TITLE
Fixes on game import and vertex color mixing

### DIFF
--- a/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
+++ b/io_scene_nif/modules/nif_import/property/nodes_wrapper/__init__.py
@@ -134,6 +134,10 @@ class NodesWrapper:
             if texture_type in ("Detail", "Reflect"):
                 rgb_mixer.inputs[0].default_value = 1
                 rgb_mixer.blend_type = "OVERLAY"
+            # these textures are multiplied with the base texture (currently only vertex color)
+            elif texture_type == "Vertex_Color":
+                rgb_mixer.inputs[0].default_value = 1
+                rgb_mixer.blend_type = "MULTIPLY"
             # these textures use their alpha channel as a mask over the input pass
             elif texture_type == "Decal":
                 self.tree.links.new(b_texture_node.outputs[1], rgb_mixer.inputs[0])
@@ -146,7 +150,7 @@ class NodesWrapper:
         # if ob.data.vertex_colors:
         self.vcol = self.tree.nodes.new('ShaderNodeVertexColor')
         self.vcol.layer_name = "RGBA"
-        self.diffuse_pass = self.connect_to_pass(self.diffuse_pass, self.vcol, texture_type="Detail")
+        self.diffuse_pass = self.connect_to_pass(self.diffuse_pass, self.vcol, texture_type="Vertex_Color")
 
     def connect_to_output(self, has_vcol=False):
         if has_vcol:

--- a/io_scene_nif/modules/nif_import/scene/__init__.py
+++ b/io_scene_nif/modules/nif_import/scene/__init__.py
@@ -62,7 +62,7 @@ def import_version_info(data):
                     continue
                 #same checks for user version 2
                 if game_enum in scene.USER_VERSION_2:
-                    if scene.USER_VERSION_2[game_enum] != scene.user_version:
+                    if scene.USER_VERSION_2[game_enum] != scene.user_version_2:
                         continue
                 elif scene.user_version_2 != 0:
                     continue

--- a/io_scene_nif/modules/nif_import/scene/__init__.py
+++ b/io_scene_nif/modules/nif_import/scene/__init__.py
@@ -40,6 +40,7 @@
 import bpy
 from pyffi.formats.nif import NifFormat
 from io_scene_nif.properties.scene import _game_to_enum
+from io_scene_nif.utils.util_logging import NifLog
 
 def import_version_info(data):
     scene = bpy.context.scene.niftools_scene


### PR DESCRIPTION
@niftools/blender-nif-plugin-reviewer 

# Overview
See title

##  Detailed Description
- Fixed game import user version checking user version where it should have been checking user version 2 due to typo.
- Fixed error on import of specific user version combinations due to NifLog not being imported
- Changed vertex color import from 'Overlay' to 'Multiply' mixing with the base texture, to bring it in line with how NifSkope displays it.

## Fixes Known Issues
#379 

## Documentation
[Overview of updates to documentation]

## Testing
[Overview of testing required to ensure functionality is correctly implemented]

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
[Anything else you deem relevant]

